### PR TITLE
Add cluster route table and feature value for VPC peering

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -119,6 +119,8 @@ paths:
     $ref: './resources/OrganizationClusterRef.yaml'
   /organization/{organizationId}/cluster/{clusterId}/status:
     $ref: './resources/OrganizationClusterStatus.yaml'
+  /organization/{organizationId}/cluster/{clusterId}/routingTable:
+    $ref: './resources/OrganizationClusterRoutingTable.yaml'
   /organization/{organizationId}/aws/credentials:
     $ref: './resources/CloudProviderAWSCredentials.yaml'
   /organization/{organizationId}/aws/credentials/{credentialsId}:

--- a/src/resources/OrganizationClusterRoutingTable.yaml
+++ b/src/resources/OrganizationClusterRoutingTable.yaml
@@ -1,0 +1,52 @@
+get:
+  summary: 'Get routing table'
+  description: Retrieve network routing table where each line corresponds to a route between a destination and a target.
+  operationId: getRoutingTable
+  parameters:
+    - $ref: '../parameters/path/organizationId.yaml'
+    - $ref: '../parameters/path/clusterId.yaml'
+  tags:
+    - Clusters
+  responses:
+    '200':
+      description: 'Routing table'
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ClusterRoutingTableResponse.yaml'
+    '401':
+      $ref: '../responses/NotAuthorized.yaml'
+    '403':
+      $ref: '../responses/Forbidden.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
+
+post:
+  summary: 'Edit routing table'
+  description: Edit routing table by returning updated table.
+  operationId: editRoutingTable
+  parameters:
+    - $ref: '../parameters/path/organizationId.yaml'
+    - $ref: '../parameters/path/clusterId.yaml'
+  tags:
+    - Clusters
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/ClusterRoutingTableRequest.yaml'
+  responses:
+    '201':
+      description: 'Updated routing table'
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ClusterRoutingTableResponse.yaml'
+    '400':
+      $ref: '../responses/BadRequest.yaml'
+    '401':
+      $ref: '../responses/NotAuthorized.yaml'
+    '403':
+      $ref: '../responses/Forbidden.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'

--- a/src/resources/OrganizationClusterRoutingTable.yaml
+++ b/src/resources/OrganizationClusterRoutingTable.yaml
@@ -21,7 +21,7 @@ get:
     '404':
       $ref: '../responses/NotFound.yaml'
 
-post:
+put:
   summary: 'Edit routing table'
   description: Edit routing table by returning updated table.
   operationId: editRoutingTable

--- a/src/schemas/ClusterFeatureResponse.yaml
+++ b/src/schemas/ClusterFeatureResponse.yaml
@@ -33,5 +33,5 @@ properties:
     type: boolean
     default: false
   accepted_values:
+    nullable: false
     type: array
-    nullable: true

--- a/src/schemas/ClusterFeatureResponse.yaml
+++ b/src/schemas/ClusterFeatureResponse.yaml
@@ -32,3 +32,6 @@ properties:
   is_value_updatable:
     type: boolean
     default: false
+  accepted_values:
+    type: array
+    nullable: true

--- a/src/schemas/ClusterRoutingTableRequest.yaml
+++ b/src/schemas/ClusterRoutingTableRequest.yaml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - results
+properties:
+  results:
+    type: array
+    items:
+      type: object
+      required:
+        - destination
+        - target
+      properties:
+        destination:
+          type: string
+        target:
+          type: string
+        description:
+          type: string

--- a/src/schemas/ClusterRoutingTableResponse.yaml
+++ b/src/schemas/ClusterRoutingTableResponse.yaml
@@ -7,10 +7,7 @@ properties:
       properties:
         destination:
           type: string
-          nullable: false
         target:
           type: string
-          nullable: false
         description:
           type: string
-          nullable: true

--- a/src/schemas/ClusterRoutingTableResponse.yaml
+++ b/src/schemas/ClusterRoutingTableResponse.yaml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  results:
+    type: array
+    items:
+      type: object
+      properties:
+        destination:
+          type: string
+          nullable: false
+        target:
+          type: string
+          nullable: false
+        description:
+          type: string
+          nullable: true

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -392,6 +392,10 @@ Cluster:
   $ref: ./Cluster.yaml
 ClusterFeatureResponse:
   $ref: ./ClusterFeatureResponse.yaml
+ClusterRoutingTableResponse:
+  $ref: ./ClusterRoutingTableResponse.yaml
+ClusterRoutingTableRequest:
+  $ref: ./ClusterRoutingTableRequest.yaml
 ClusterFeatureResponseList:
   $ref: ./ClusterFeatureResponseList.yaml
 InviteMemberResponseList:


### PR DESCRIPTION
- I added missing parameter "accepted_values" in **/{cloudProvider}/ClusterFeature** endpoint to get available values
- I created  **/organization/{organizationId}/cluster/{clusterId}/routingTable** endpoint to get and edit routing table 
- These updates meet the needs for VPC peering
