### PR TITLE
udpate environment deployment rule response

### DIFF
--- a/src/resources/EnvironmentDeploymentHistory.yaml
+++ b/src/resources/EnvironmentDeploymentHistory.yaml
@@ -1,6 +1,6 @@
 get:
-  summary: 'List environment deploys'
-  description: By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter
+  summary: 'List environment deployments'
+  description: List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter
   operationId: listEnvironmentDeploymentHistory
   parameters:
     - $ref: '../parameters/path/environmentId.yaml'

--- a/src/schemas/DeploymentHistoryApplicationResponse.yaml
+++ b/src/schemas/DeploymentHistoryApplicationResponse.yaml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  name:
+    type: string
+  commit:
+    $ref: './CommitResponse.yaml'
+  status:
+    type: string
+    enum:
+      - SUCCESS
+      - FAILED
+allOf:
+- $ref: './BaseResponse.yaml'

--- a/src/schemas/DeploymentHistoryApplicationResponse.yaml
+++ b/src/schemas/DeploymentHistoryApplicationResponse.yaml
@@ -7,7 +7,23 @@ properties:
   status:
     type: string
     enum:
-      - SUCCESS
-      - FAILED
+      - READY
+      - BUILDING
+      - BUILD_ERROR
+      - BUILT
+      - DEPLOYMENT_QUEUED
+      - DEPLOYING
+      - DEPLOYMENT_ERROR
+      - DEPLOYED
+      - STOP_QUEUED
+      - STOPPING
+      - STOP_ERROR
+      - STOPPED
+      - DELETE_QUEUED
+      - DELETING
+      - DELETE_ERROR
+      - DELETED
+      - RUNNING
+      - RUNNING_ERROR
 allOf:
 - $ref: './BaseResponse.yaml'

--- a/src/schemas/DeploymentHistoryDatabaseResponse.yaml
+++ b/src/schemas/DeploymentHistoryDatabaseResponse.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  name:
+    type: string
+  status:
+    type: string
+    enum:
+      - SUCCESS
+      - FAILED
+allOf:
+- $ref: './BaseResponse.yaml'

--- a/src/schemas/DeploymentHistoryDatabaseResponse.yaml
+++ b/src/schemas/DeploymentHistoryDatabaseResponse.yaml
@@ -5,7 +5,23 @@ properties:
   status:
     type: string
     enum:
-      - SUCCESS
-      - FAILED
+      - READY
+      - BUILDING
+      - BUILD_ERROR
+      - BUILT
+      - DEPLOYMENT_QUEUED
+      - DEPLOYING
+      - DEPLOYMENT_ERROR
+      - DEPLOYED
+      - STOP_QUEUED
+      - STOPPING
+      - STOP_ERROR
+      - STOPPED
+      - DELETE_QUEUED
+      - DELETING
+      - DELETE_ERROR
+      - DELETED
+      - RUNNING
+      - RUNNING_ERROR
 allOf:
 - $ref: './BaseResponse.yaml'

--- a/src/schemas/DeploymentHistoryEnvironmentResponse.yaml
+++ b/src/schemas/DeploymentHistoryEnvironmentResponse.yaml
@@ -3,8 +3,24 @@ properties:
   status:
     type: string
     enum:
-      - SUCCESS
-      - FAILED
+      - READY
+      - BUILDING
+      - BUILD_ERROR
+      - BUILT
+      - DEPLOYMENT_QUEUED
+      - DEPLOYING
+      - DEPLOYMENT_ERROR
+      - DEPLOYED
+      - STOP_QUEUED
+      - STOPPING
+      - STOP_ERROR
+      - STOPPED
+      - DELETE_QUEUED
+      - DELETING
+      - DELETE_ERROR
+      - DELETED
+      - RUNNING
+      - RUNNING_ERROR
   applications:
     type: array
     items:

--- a/src/schemas/DeploymentHistoryEnvironmentResponse.yaml
+++ b/src/schemas/DeploymentHistoryEnvironmentResponse.yaml
@@ -1,17 +1,17 @@
 type: object
 properties:
-  service:
-    type: object
-    properties:
-      type:
-        type: string
-        enum:
-          - APPLICATION
-          - DATABASE
-      name:
-        type: string
-      id:
-        type: string
-        format: uuid
+  status:
+    type: string
+    enum:
+      - SUCCESS
+      - FAILED
+  applications:
+    type: array
+    items:
+      - $ref: './DeploymentHistoryApplicationResponse.yaml'
+  databases:
+      type: array
+      items:
+        - $ref: './DeploymentHistoryDatabaseResponse.yaml'
 allOf:
-  - $ref: './DeploymentHistoryResponse.yaml'
+  - $ref: './BaseResponse.yaml'

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -122,6 +122,10 @@ EventResponseList:
   $ref: ./EventResponseList.yaml
 DeploymentHistoryResponse:
   $ref: ./DeploymentHistoryResponse.yaml
+DeploymentHistoryApplicationResponse:
+  $ref: ./DeploymentHistoryApplicationResponse.yaml
+DeploymentHistoryDatabaseResponse:
+  $ref: ./DeploymentHistoryDatabaseResponse.yaml
 OrganizationResponseList:
   $ref: ./OrganizationResponseList.yaml
 ClusterRequest:


### PR DESCRIPTION
I updated existing environment deployment rules response.
- Allow to get more than one service per environment deployment
- Split services between applications and databases, as db cannot have commit parameter. 