### PR TITLE
Add service restart metric

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -261,6 +261,8 @@ paths:
     $ref: './resources/ApplicationMetricHealthCheck.yaml'
   /application/{applicationId}/metric/storage:
     $ref: './resources/ApplicationMetricStorage.yaml'
+  /application/{applicationId}/metric/restart:
+    $ref: './resources/ApplicationMetricRestart.yaml'
   /application/{applicationId}/dependency:
     $ref: './resources/ApplicationDependency.yaml'
   /application/{applicationId}/dependency/{targetApplicationId}:
@@ -347,6 +349,8 @@ paths:
     $ref: './resources/DatabaseMetricStorage.yaml'
   /database/{databaseId}/metric/healthCheck:
     $ref: './resources/DatabaseMetricHealthCheck.yaml'
+  /database/{databaseId}/metric/restart:
+    $ref: './resources/DatabaseMetricRestart.yaml'
   /database/{databaseId}/backup:
     $ref: './resources/DatabaseBackup.yaml'
   /database/{databaseId}/backup/{backupId}:

--- a/src/resources/ApplicationMetricRestart.yaml
+++ b/src/resources/ApplicationMetricRestart.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: 'List application restarts'
+  description: 'Get application restart message and timestamp.'
+  operationId: getApplicationMetricRestart
+  parameters:
+    - $ref: '../parameters/path/applicationId.yaml'
+    - $ref: '../parameters/query/lastSeconds.yaml'
+  tags:
+    - Application Metrics
+  responses:
+    '200':
+      description: 'Restarts'
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/MetricRestartResponse.yaml'
+    '401':
+      $ref: '../responses/NotAuthorized.yaml'
+    '403':
+      $ref: '../responses/Forbidden.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'

--- a/src/resources/DatabaseMetricRestart.yaml
+++ b/src/resources/DatabaseMetricRestart.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: 'List database restarts'
+  description: 'Get database restart message and timestamp.'
+  operationId: getDatabaseMetricRestart
+  parameters:
+    - $ref: '../parameters/path/applicationId.yaml'
+    - $ref: '../parameters/query/lastSeconds.yaml'
+  tags:
+    - Database Metrics
+  responses:
+    '200':
+      description: 'Restarts'
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/MetricRestartResponse.yaml'
+    '401':
+      $ref: '../responses/NotAuthorized.yaml'
+    '403':
+      $ref: '../responses/Forbidden.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'

--- a/src/schemas/MetricRestartResponse.yaml
+++ b/src/schemas/MetricRestartResponse.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  results:
+    type: array
+    items:
+      type: object
+      required:
+        - datetime
+        - message
+      properties:
+        datetime:
+          type: string
+          format: date-time
+        message:
+          type: string

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -338,6 +338,8 @@ InstanceResponse:
   $ref: ./InstanceResponse.yaml
 MetricStorageResponseList:
   $ref: ./MetricStorageResponseList.yaml
+MetricRestartResponse:
+  $ref: ./MetricRestartResponse.yaml
 EventResponse:
   $ref: ./EventResponse.yaml
 EnvironmentDatabasesCurrentMetricResponseList:


### PR DESCRIPTION
I added new endpoints to get list of service (database and application) restart.
- Format is a list of {<datetime>, <message>}