### PR TITLE
adding generation of swagger.json

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -17,6 +17,7 @@ jobs:
           npm ci
           npm run build
           npm run html
+          npm run generate-swagger-json
       - name: Deploy to GitHub Pages
         run: npm run deploy
         env:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "html": "npm run build && redoc-cli bundle _build/openapi.yaml  --output _build/index.html --options src/theme.json",
     "clean": "rm -r _build",
     "deploy": "./deploy.sh",
-    "generate": "./clean_out.sh out _build && npm run test && openapi-generator-cli generate -i _build/openapi.yaml -o out/client -g $QOVERY_CLIENT_LANGUAGE -a bearer --api-package api --package-name qovery --model-package  model"
+    "generate": "./clean_out.sh out _build && npm run test && openapi-generator-cli generate -i _build/openapi.yaml -o out/client -g $QOVERY_CLIENT_LANGUAGE -a bearer --api-package api --package-name qovery --model-package  model",
+    "generate-swagger-json": "swagger-cli bundle src/openapi.yaml --outfile _build/swagger.json --type json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Frontend team for the v3 architecture needs to be able to download from swagger.json from the website [api-doc](https://api-doc.qovery.com/)

This pull request adds a npm command for the generation of this swagger.json
Modify the script of github page to run this npm command
The rest is left untouched, the file generated should be created and copied at the same level of index.html which should allows us to download the file at this URL: https://api-doc.qovery.com/swagger.json