### PR TITLE
feat: add msg to db cpu/ram fields for managed DB

### DIFF
--- a/src/schemas/DatabaseEditRequest.yaml
+++ b/src/schemas/DatabaseEditRequest.yaml
@@ -13,13 +13,16 @@ properties:
     $ref: './enums/DatabaseAccessibility.yaml'
   cpu:
     type: integer
-    description: unit is millicores (m). 1000m = 1 cpu
+    description: |
+      unit is millicores (m). 1000m = 1 cpu.
+      This field will be ignored for managed DB (instance type will be used instead).
     default: 250
     example: 1250
   memory:
     type: integer
     description: |
-      unit is MB. 1024 MB = 1GB  
+      unit is MB. 1024 MB = 1GB
+      This field will be ignored for managed DB (instance type will be used instead).
       Default value is linked to the database type:
       - MANAGED: 100
       - CONTAINER

--- a/src/schemas/DatabaseRequest.yaml
+++ b/src/schemas/DatabaseRequest.yaml
@@ -22,7 +22,9 @@ properties:
     $ref: './enums/DatabaseAccessibility.yaml'
   cpu:
     type: integer
-    description: unit is millicores (m). 1000m = 1 cpu
+    description: |
+      unit is millicores (m). 1000m = 1 cpu
+      This field will be ignored for managed DB (instance type will be used instead).
     default: 250
     example: 1250
   instance_type:
@@ -32,7 +34,8 @@ properties:
   memory:
     type: integer
     description: |
-      unit is MB. 1024 MB = 1GB  
+      unit is MB. 1024 MB = 1GB
+      This field will be ignored for managed DB (instance type will be used instead).
       Default value is linked to the database type:
       - MANAGED: `100`
       - CONTAINER


### PR DESCRIPTION
This CL to add a deszcription message on managed DB cpu and memory
fields explaning those won't be taken into account but instance type in
the case of managed DB.

Tciket: COR-604
