### PR TITLE
fix(schemas): fix registry type which can be null

### DIFF
--- a/src/schemas/job/JobResponse.yaml
+++ b/src/schemas/job/JobResponse.yaml
@@ -20,6 +20,7 @@ allOf:
         $ref: '../ReferenceObject.yaml'
       registry:
         $ref: '../ReferenceObject.yaml'
+        nullable: true
       maximum_cpu:
         type: integer
         description: Maximum cpu that can be allocated to the job based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu


### PR DESCRIPTION
Job aren't necessarily linked to a container registry.
Eg. https://console.qovery.com/organization/460616f0-94da-4d35-b631-6fa4ed08eb9a/project/61acd49c-41d9-4354-8e8c-9ae502273a0c/environment/1b74b4b8-c770-45b4-922b-10417569c08c/application/be9e3008-1661-480e-a524-83aa1a40b63f/general
Which is git based.