### PR TITLE
fix(git-tokens): preserve previous params order

### DIFF
--- a/src/resources/OrganizationAccountGitRepositoryBitbucketBranch.yaml
+++ b/src/resources/OrganizationAccountGitRepositoryBitbucketBranch.yaml
@@ -6,16 +6,16 @@ get:
   parameters:
     - $ref: '../parameters/path/organizationId.yaml'
     - in: query
+      name: name
+      schema:
+        type: string
+      description: The name of the repository where to retrieve the branches
+    - in: query
       name: gitTokenId
       schema:
         type: string
         format: uuid
       description: The git token id that must be used for the application
-    - in: query
-      name: name
-      schema:
-        type: string
-      description: The name of the repository where to retrieve the branches
   responses:
     '200':
       description: 'Get bitbucket repository branches'

--- a/src/resources/OrganizationAccountGitRepositoryGithubBranch.yaml
+++ b/src/resources/OrganizationAccountGitRepositoryGithubBranch.yaml
@@ -6,16 +6,16 @@ get:
   parameters:
     - $ref: '../parameters/path/organizationId.yaml'
     - in: query
+      name: name
+      schema:
+        type: string
+      description: The name of the repository where to retrieve the branches
+    - in: query
       name: gitTokenId
       schema:
         type: string
         format: uuid
       description: The git token id that must be used for the application
-    - in: query
-      name: name
-      schema:
-        type: string
-      description: The name of the repository where to retrieve the branches
   responses:
     '200':
       description: 'Get github repository branches'

--- a/src/resources/OrganizationAccountGitRepositoryGitlabBranch.yaml
+++ b/src/resources/OrganizationAccountGitRepositoryGitlabBranch.yaml
@@ -6,16 +6,16 @@ get:
   parameters:
     - $ref: '../parameters/path/organizationId.yaml'
     - in: query
+      name: name
+      schema:
+        type: string
+      description: The name of the repository to retrieve the branches
+    - in: query
       name: gitTokenId
       schema:
         type: string
         format: uuid
       description: The git token id that must be used for the application
-    - in: query
-      name: name
-      schema:
-        type: string
-      description: The name of the repository to retrieve the branches
   responses:
     '200':
       description: 'Get gitlab repository branches'


### PR DESCRIPTION
TS generated client relies on params declaration order to generate function like `func(param1, param2)`.
So order MUST be preserved even if this is named param.