### PR TITLE
fix: add routing table required fields

### DIFF
--- a/src/schemas/ClusterRoutingTableResponse.yaml
+++ b/src/schemas/ClusterRoutingTableResponse.yaml
@@ -4,6 +4,10 @@ properties:
     type: array
     items:
       type: object
+      required:
+        - destination
+        - target
+        - description
       properties:
         destination:
           type: string


### PR DESCRIPTION
[Cluster Routing Table Request](https://github.com/Qovery/qovery-openapi-spec/blob/488c09f081bdf845c34a02e8af47fa0ecb89ac65/src/schemas/ClusterRoutingTableRequest.yaml) have required fields where [Response](https://github.com/Qovery/qovery-openapi-spec/blob/488c09f081bdf845c34a02e8af47fa0ecb89ac65/src/schemas/ClusterRoutingTableResponse.yaml) doesn't mark them as required.



