### PR TITLE
feat(QOV-39): add missing case for OrganizationEventType

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17913,6 +17913,7 @@ components:
         - STOP_FAILED
         - DELETE_FAILED
         - RESTART_FAILED
+        - MAINTENANCE
       example: CREATE
     SecretOverride:
       type: object


### PR DESCRIPTION
As part of [QOV-39](https://qovery.atlassian.net/browse/QOV-39), I discovered the `MAINTENANCE` case was missing from the `OrganizationEventType`. This PR fixes that.

Don't hesitate to let me know if some other cases are missing, I could update this PR to take them into account.

[QOV-39]: https://qovery.atlassian.net/browse/QOV-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ