### PR TITLE
fix(QOV-618): correct case for serviceType enum

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11421,9 +11421,9 @@ paths:
       - schema:
           type: string
           enum:
-            - container
-            - application
-            - helm
+            - CONTAINER
+            - APPLICATION
+            - HELM
         name: serviceType
         in: path
         required: true


### PR DESCRIPTION
[Jira ticket](https://qovery.atlassian.net/browse/QOV-618)

[Related PR](https://github.com/Qovery/qovery-openapi-spec/pull/795/files)

This PR simply updates the values of the `GetIngressDeploymentStatusServiceTypeEnum` for them to be uppercase to follow the case of the values of the other already declared `serviceType` enums.