### PR TITLE
impr: add Terraform to OrganizationEventTargetType

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18483,6 +18483,7 @@ components:
         - ORGANIZATION
         - PROJECT
         - WEBHOOK
+        - TERRAFORM
       example: APPLICATION
       title: ''
     OrganizationEventType:


### PR DESCRIPTION
This PR adds the missing `TERRAFORM` value to `OrganizationEventTargetType`