### PR TITLE
impr: make "value" property mandatory in TerraformDeploymentRestrictionRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22011,6 +22011,7 @@ components:
       required:
         - mode
         - type
+        - value
       properties:
         mode:
           $ref: '#/components/schemas/DeploymentRestrictionModeEnum'


### PR DESCRIPTION
In order to align with other `DeploymentRestriction` requests, this PR makes the "value" property of the `TerraformDeploymentRestrictionRequest` payload mandatory.