### PR TITLE
fix: redeployTerraform typo

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10151,7 +10151,7 @@ paths:
   '/terraform/{terraformId}/redeploy':
     post:
       summary: Redeploy terraform
-      operationId: redeployTerrraform
+      operationId: redeployTerraform
       responses:
         '202':
           description: Terraform redeploy has been requested


### PR DESCRIPTION
This PR fixes a small typo in the value of the `operationId` field for the `/terraform/{terraformId}/redeploy` endpoint