### PR TITLE
feat(argocd): add GET /argocdApp/{id}/manifest endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13291,6 +13291,27 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+  '/argocdApp/{argocdAppId}/manifest':
+    get:
+      summary: Get ArgoCD app manifest enrichment
+      operationId: getArgoCdAppManifest
+      parameters:
+        - $ref: '#/components/parameters/argocdAppId'
+      tags:
+        - ArgoCD
+      responses:
+        '200':
+          description: Manifest enrichment for the ArgoCD app, including managed Kubernetes resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArgocdAppManifestResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   '/organization/{organizationId}/credentials':
     parameters:
       - schema:
@@ -27362,6 +27383,39 @@ components:
               type: string
               nullable: true
       description: An ArgoCD service
+    ArgocdAppManifestResponse:
+      type: object
+      required:
+        - manifest_metadata
+      properties:
+        manifest_revision:
+          type: string
+          nullable: true
+          description: Git revision the app is currently synced to
+        manifest_metadata:
+          type: object
+          description: Raw enrichment data fetched from the ArgoCD managed-resources API
+          properties:
+            managed_resources:
+              type: array
+              items:
+                $ref: '#/components/schemas/ArgocdManagedResource'
+    ArgocdManagedResource:
+      type: object
+      properties:
+        kind:
+          type: string
+          description: Kubernetes resource kind (e.g. Deployment, Service)
+        name:
+          type: string
+        namespace:
+          type: string
+        targetState:
+          type: string
+          description: JSON-encoded desired Kubernetes manifest
+        liveState:
+          type: string
+          description: JSON-encoded live Kubernetes manifest
     ProviderSecrets:
       type: object
       required:

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -356,6 +356,20 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/ServiceType'
+      - name: argocd_app_name
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: argocd_namespace
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          - 'null'
       responses:
         '200':
           description: Stream of services metrics

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -356,20 +356,6 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/ServiceType'
-      - name: argocd_app_name
-        in: path
-        required: true
-        schema:
-          type:
-          - string
-          - 'null'
-      - name: argocd_namespace
-        in: path
-        required: true
-        schema:
-          type:
-          - string
-          - 'null'
       responses:
         '200':
           description: Stream of services metrics


### PR DESCRIPTION
## Summary
- Add `GET /argocdApp/{argocdAppId}/manifest` endpoint returning manifest enrichment data
- Add `ArgocdAppManifestResponse` schema with `manifest_revision` and `manifest_metadata` (contains `managed_resources` array)
- Add `ArgocdManagedResource` schema with `kind`, `name`, `namespace`, `targetState`, `liveState`

## Test plan
- [ ] Schema validates (YAML is well-formed)
- [ ] New path and schemas visible in generated API docs