### PR TITLE
feat(QOV-1844): add organization onboarding endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1325,6 +1325,98 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+  '/organization/{organizationId}/onboarding':
+    get:
+      summary: Get the onboarding status of an organization
+      description: |
+        Returns the onboarding status for the given organization and the use cases selected by the owner at sign-up.
+
+        **Example response when onboarding is in progress:**
+        ```json
+        {
+          "use_cases": "ephemeral-environments,rde",
+          "status": "IN_PROGRESS"
+        }
+        ```
+
+        **Example response when the owner dismissed the onboarding:**
+        ```json
+        {
+          "use_cases": "ephemeral-environments",
+          "status": "DISMISSED"
+        }
+        ```
+
+        **Example response for an organization whose owner never went through sign-up questions:**
+        ```json
+        {
+          "use_cases": null,
+          "status": null
+        }
+        ```
+      operationId: getOrganizationOnboarding
+      parameters:
+        - $ref: '#/components/parameters/organizationId'
+      tags:
+        - Organization Main Calls
+      responses:
+        '200':
+          description: Onboarding status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationOnboardingResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+    post:
+      summary: Update the onboarding status of an organization
+      description: |
+        Updates the onboarding status for the calling user's organization. Only the authenticated user's own sign-up record is updated.
+
+        **Mark onboarding as dismissed:**
+        ```json
+        { "status": "DISMISSED" }
+        ```
+
+        **Mark onboarding as completed:**
+        ```json
+        { "status": "COMPLETED" }
+        ```
+
+        **Reset to in-progress:**
+        ```json
+        { "status": "IN_PROGRESS" }
+        ```
+      operationId: updateOrganizationOnboarding
+      parameters:
+        - $ref: '#/components/parameters/organizationId'
+      tags:
+        - Organization Main Calls
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationOnboardingPatchRequest'
+      responses:
+        '200':
+          description: Updated onboarding status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationOnboardingResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   '/organization/{organizationId}/cluster':
     get:
       summary: List organization clusters
@@ -22870,6 +22962,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Organization'
+    OrganizationOnboardingResponse:
+      type: object
+      properties:
+        use_cases:
+          type: string
+          nullable: true
+          description: Comma-separated list of use cases selected by the organization owner at sign-up (e.g. "ephemeral-environments,rde")
+          example: 'ephemeral-environments,rde'
+        status:
+          $ref: '#/components/schemas/OrganizationOnboardingStatusEnum'
+    OrganizationOnboardingPatchRequest:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/OrganizationOnboardingStatusEnum'
+    OrganizationOnboardingStatusEnum:
+      type: string
+      enum:
+        - IN_PROGRESS
+        - DISMISSED
+        - COMPLETED
     OrganizationEventResponse:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1328,32 +1328,7 @@ paths:
   '/organization/{organizationId}/onboarding':
     get:
       summary: Get the onboarding status of an organization
-      description: |
-        Returns the onboarding status for the given organization and the use cases selected by the owner at sign-up.
-
-        **Example response when onboarding is in progress:**
-        ```json
-        {
-          "use_cases": "ephemeral-environments,rde",
-          "status": "IN_PROGRESS"
-        }
-        ```
-
-        **Example response when the owner dismissed the onboarding:**
-        ```json
-        {
-          "use_cases": "ephemeral-environments",
-          "status": "DISMISSED"
-        }
-        ```
-
-        **Example response for an organization whose owner never went through sign-up questions:**
-        ```json
-        {
-          "use_cases": null,
-          "status": null
-        }
-        ```
+      description: Returns the onboarding status for the given organization and the use cases selected by the owner at sign-up.
       operationId: getOrganizationOnboarding
       parameters:
         - $ref: '#/components/parameters/organizationId'
@@ -1374,23 +1349,7 @@ paths:
           $ref: '#/components/responses/404'
     post:
       summary: Update the onboarding status of an organization
-      description: |
-        Updates the onboarding status for the calling user's organization. Only the authenticated user's own sign-up record is updated.
-
-        **Mark onboarding as dismissed:**
-        ```json
-        { "status": "DISMISSED" }
-        ```
-
-        **Mark onboarding as completed:**
-        ```json
-        { "status": "COMPLETED" }
-        ```
-
-        **Reset to in-progress:**
-        ```json
-        { "status": "IN_PROGRESS" }
-        ```
+      description: Updates the onboarding status for the calling user's organization. Only the authenticated user's own sign-up record is updated.
       operationId: updateOrganizationOnboarding
       parameters:
         - $ref: '#/components/parameters/organizationId'


### PR DESCRIPTION
Summary

  Adds the two onboarding endpoints introduced in q-core as part of the organization onboarding feature.

  - GET /organization/{organizationId}/onboarding — returns the onboarding status
  and use cases for the organization owner
  - POST /organization/{organizationId}/onboarding — updates the onboarding
  status (transition between IN_PROGRESS, DISMISSED, COMPLETED)

  Notes

  - use_cases is a comma-separated string of sign-up selections (e.g. "ephemeral-environments,rde"), stripped of internal onboarding keys)
  - status is null when the organization owner never went through the sign-up flow
  - Both endpoints require membership access to the organization