### PR TITLE
feat(blueprint): document field type + constraints on update-check

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15215,26 +15215,81 @@ components:
         updated_values:
           type: array
           items:
-            $ref: '#/components/schemas/BlueprintUpdateUpdatedValue'
+            $ref: '#/components/schemas/BlueprintUpdateEngineFieldChange'
     BlueprintUpdateNewRequiredValue:
       type: object
       required:
         - name
+        - type
+        - is_secret
       properties:
         name:
           type: string
+        type:
+          $ref: '#/components/schemas/BlueprintManifestFieldType'
+        allowed_values:
+          type: array
+          nullable: true
+          description: Values the user may choose from. Null = unrestricted.
+          items:
+            type: string
+        is_secret:
+          type: boolean
     BlueprintUpdateNewOptionalValue:
       type: object
       required:
         - name
+        - type
+        - is_secret
       properties:
         name:
           type: string
         default_value:
           type: string
           nullable: true
+        type:
+          $ref: '#/components/schemas/BlueprintManifestFieldType'
+        allowed_values:
+          type: array
+          nullable: true
+          description: Values the user may choose from. Null = unrestricted.
+          items:
+            type: string
+        is_secret:
+          type: boolean
     BlueprintUpdateUpdatedValue:
       type: object
+      required:
+        - name
+        - type
+        - is_secret
+      properties:
+        name:
+          type: string
+        current_default_value:
+          type: string
+          nullable: true
+        new_default_value:
+          type: string
+          nullable: true
+        current_value:
+          type: string
+          nullable: true
+        type:
+          $ref: '#/components/schemas/BlueprintManifestFieldType'
+        allowed_values:
+          type: array
+          nullable: true
+          description: Values the user may choose from. Null = unrestricted.
+          items:
+            type: string
+        is_secret:
+          type: boolean
+    BlueprintUpdateEngineFieldChange:
+      type: object
+      description: >-
+        A single engine-block field delta (e.g. version, cpu, ram). Not a
+        manifest variable, so it carries no field type or constraints.
       required:
         - name
       properties:


### PR DESCRIPTION
#### What
Enriches the `BlueprintUpdateResponse` schemas so the new-required, new-optional, now-required and updated variable entries carry the field `type` (`BlueprintManifestFieldType`), `allowed_values` and `is_secret`. Splits the engine-diff entries into a dedicated `BlueprintUpdateEngineFieldChange` schema (name + default/current deltas, no type/constraints).

#### Why
Mirrors the q-core change that adds this metadata to `GET /blueprint/{blueprintId}/update`. The update form needs the same field type/constraint info the create-form manifest endpoint already exposes, in order to render and validate inputs the way the create form does.

#### Notes
Reuses the existing `BlueprintManifestFieldType` schema (the same flat, `type`-discriminated shape Jackson emits). `allowed_values` stays nullable (`null` = no enum constraint), matching the create-form field schema. Engine fields (version/cpu/ram) are not manifest variables, so they get a separate schema rather than overloading `BlueprintUpdateUpdatedValue`.

Paired q-core MR: `feat/blueprint-update-field-type`.