### PR TITLE
docs(blueprint): document 409 on createBlueprint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14155,6 +14155,8 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          description: A service with this name already exists in the environment
         '422':
           description: Malformed blueprint tag
         '502':


### PR DESCRIPTION
What:
Add a 409 response to the createBlueprint operation (POST /environment/{environmentId}/blueprint).

Why:
q-core now rejects a create when a service of the same name already exists in the environment (type-scoped), returning 409 CONFLICT. Clients (incl. the console) need the documented response to surface a proper "name already used" error.

Notes:
Inline description, matching the existing 422/502 style — no reusable 409 response component exists in this spec.