### PR TITLE
feat(blueprint): add new_major_versions to blueprint update response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15172,6 +15172,7 @@ components:
         - updated_values
         - removed_values
         - engine_diff
+        - new_major_versions
       properties:
         is_up_to_date:
           type: boolean
@@ -15205,6 +15206,14 @@ components:
             $ref: '#/components/schemas/BlueprintUpdateRemovedValue'
         engine_diff:
           $ref: '#/components/schemas/BlueprintUpdateEngineDiff'
+        new_major_versions:
+          type: array
+          description: >-
+            Major versions of the same blueprint newer than the service's current
+            one (e.g. service on aws/postgres/16 while 17 and 18 exist). Empty when
+            already on the latest major or when the current version is non-numeric.
+          items:
+            $ref: '#/components/schemas/BlueprintUpdateNewMajorVersion'
     BlueprintUpdateEngineDiff:
       type: object
       description: >-
@@ -15311,6 +15320,21 @@ components:
       properties:
         name:
           type: string
+    BlueprintUpdateNewMajorVersion:
+      type: object
+      description: A newer major version of the blueprint available for a major upgrade.
+      required:
+        - service_version
+        - latest_tag
+      properties:
+        service_version:
+          type: string
+          description: The engine major version (e.g. "17").
+          example: "17"
+        latest_tag:
+          type: string
+          description: Latest catalog tag for that major version.
+          example: aws/postgres/17/1.0.1
     BlueprintUpdatePreviewResponse:
       type: object
       required:


### PR DESCRIPTION
What:
BlueprintUpdateResponse now carries a required new_major_versions[] field, each item a BlueprintUpdateNewMajorVersion { service_version, latest_tag }.

Why:
GET /api/blueprint/{id}/update now reports major versions newer than the service's current one so clients can offer a major upgrade.

Notes:
Always present; empty when already on the latest major or when the current service version is non-numeric (e.g. "default"). 