### PR TITLE
feat(blueprint): add current_tag to update availability response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15937,6 +15937,7 @@ components:
       type: object
       required:
         - is_up_to_date
+        - current_tag
         - latest_tag
         - new_required_values
         - new_optional_values
@@ -15948,6 +15949,9 @@ components:
       properties:
         is_up_to_date:
           type: boolean
+        current_tag:
+          type: string
+          example: aws/postgres/17/1.0.0
         latest_tag:
           type: string
           example: aws/postgres/17/1.1.0


### PR DESCRIPTION
What:
Add required `current_tag` (string) to BlueprintUpdateResponse, alongside `latest_tag`.

Why:
Mirrors the q-core API change: clients need the current version to render a current -> latest comparison without a second lookup.
