### PR TITLE
feat(agenticWorkflow): add AGENTIC_WORKFLOW to environment services

### DIFF
--- a/generator/patches/rust/default_service_type.diff
+++ b/generator/patches/rust/default_service_type.diff
@@ -148,7 +148,7 @@ diff --git a/src/models/service_type_enum.rs b/src/models/service_type_enum.rs
 index ff5604c..f9df852 100644
 --- a/src/models/service_type_enum.rs
 +++ b/src/models/service_type_enum.rs
-@@ -52,3 +52,10 @@ impl Default for ServiceTypeEnum {
+@@ -55,3 +55,11 @@ impl Default for ServiceTypeEnum {
      }
  }
  
@@ -159,6 +159,7 @@ index ff5604c..f9df852 100644
 +pub fn service_type_terraform() -> ServiceTypeEnum { ServiceTypeEnum::Terraform }
 +pub fn service_type_job() -> ServiceTypeEnum { ServiceTypeEnum::Job }
 +pub fn service_type_argocd_app() -> ServiceTypeEnum { ServiceTypeEnum::ArgocdApp }
++pub fn service_type_agentic_workflow() -> ServiceTypeEnum { ServiceTypeEnum::AgenticWorkflow }
 diff --git a/src/models/terraform_response.rs b/src/models/terraform_response.rs
 index afdc518..f2cf6d5 100644
 --- a/src/models/terraform_response.rs
@@ -211,4 +212,15 @@ index 9f05f76..6a22a21 100644
      pub service_type: models::ServiceTypeEnum,
      #[serde(rename = "namespace")]
      pub namespace: String,
-
+diff --git a/src/models/agentic_workflow_response.rs b/src/models/agentic_workflow_response.rs
+--- a/src/models/agentic_workflow_response.rs
++++ b/src/models/agentic_workflow_response.rs
+@@ -19,7 +19,7 @@ pub struct AgenticWorkflowResponse {
+     pub created_at: String,
+     #[serde(rename = "updated_at", skip_serializing_if = "Option::is_none")]
+     pub updated_at: Option<String>,
+-    #[serde(rename = "service_type")]
++    #[serde(rename = "service_type", default = "models::service_type_enum::service_type_agentic_workflow")]
+     pub service_type: models::ServiceTypeEnum,
+     /// name is case insensitive
+     #[serde(rename = "name")]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12617,6 +12617,7 @@ paths:
                         - $ref: '#/components/schemas/JobResponse'
                         - $ref: '#/components/schemas/TerraformResponse'
                         - $ref: '#/components/schemas/ArgocdAppResponse'
+                        - $ref: '#/components/schemas/AgenticWorkflowResponse'
                       discriminator:
                         propertyName: service_type
                         mapping:
@@ -12627,6 +12628,7 @@ paths:
                           JOB: '#/components/schemas/JobResponse'
                           TERRAFORM: '#/components/schemas/TerraformResponse'
                           ARGOCD_APP: '#/components/schemas/ArgocdAppResponse'
+                          AGENTIC_WORKFLOW: '#/components/schemas/AgenticWorkflowResponse'
       operationId: listServicesByEnvironmentId
       x-stoplight:
         id: 9adquhr5t6qx3
@@ -25095,6 +25097,7 @@ components:
         - HELM
         - TERRAFORM
         - ARGOCD_APP
+        - AGENTIC_WORKFLOW
     SignUp:
       allOf:
         - $ref: '#/components/schemas/Base'
@@ -30153,7 +30156,9 @@ components:
         - type: object
           required:
           - id
+          - service_type
           - name
+          - slug
           - description
           - webhook_ip_allowlist
           - docker_fragment
@@ -30169,9 +30174,14 @@ components:
             id:
               type: string
               format: uuid
+            service_type:
+              $ref: '#/components/schemas/ServiceTypeEnum'
             name:
               type: string
               description: name is case insensitive
+            slug:
+              type: string
+              description: URL-friendly identifier derived from the name
             description:
               type: string
             webhook_ip_allowlist:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30155,21 +30155,21 @@ components:
         - $ref: '#/components/schemas/Base'
         - type: object
           required:
-          - id
-          - service_type
-          - name
-          - slug
-          - description
-          - webhook_ip_allowlist
-          - docker_fragment
-          - enabled
-          - mcp
-          - outputs
-          - model
-          - project_repositories
-          - agent_prompt
-          - governance
-          - webhook
+            - id
+            - service_type
+            - name
+            - slug
+            - description
+            - webhook_ip_allowlist
+            - docker_fragment
+            - enabled
+            - mcp
+            - outputs
+            - model
+            - project_repositories
+            - agent_prompt
+            - governance
+            - webhook
           properties:
             id:
               type: string


### PR DESCRIPTION
listServicesByEnvironmentId returns agentic workflows since q-core wired listAgenticWorkflows into EnvironmentApiController, but the contract was never updated. Generated clients had no matching variant, so the whole services list failed to deserialize -- websocket-gateway closed the /service/status socket for every service in the environment, not just the workflow.

- add AGENTIC_WORKFLOW to ServiceTypeEnum
- add AgenticWorkflowResponse to the listServicesByEnvironmentId oneOf and discriminator mapping
- add service_type to AgenticWorkflowResponse: a discriminated oneOf cannot generate a usable variant without the discriminator on the member schema
- add slug, which core has always returned (asserted with JsonCompareMode.STRICT in EnvironmentApiControllerTest) but was missing from the schema

The rust patch needs the matching entry because openapi-generator emits an internally tagged enum, so serde consumes service_type and each variant struct needs a default -- without it deserialization fails with `missing field service_type`.