### PR TITLE
feat(audit-logs): add SKILL origin for events triggered by Qovery skills

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21727,6 +21727,7 @@ components:
         - CONSOLE
         - GIT
         - QOVERY_INTERNAL
+        - SKILL
         - TERRAFORM_PROVIDER
       example: API
     EnvironmentStatusesWithStages:
@@ -24044,6 +24045,7 @@ components:
         - CONSOLE
         - GIT
         - QOVERY_INTERNAL
+        - SKILL
         - TERRAFORM_PROVIDER
       example: API
     OrganizationEventTargetLevel:


### PR DESCRIPTION
Events reaching the API with a `QoverySkill/...` user agent are now reported with a dedicated `SKILL` origin instead of falling back to `API`.

Added to both `OrganizationEventOrigin` and `EnvironmentStatusEventOriginEnum`, which serialize the same `AuditLogOrigin` enum in q-core.