### PR TITLE
fix(agentic-workflow): return environment reference

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30159,7 +30159,7 @@ components:
           required:
             - id
             - service_type
-            - environment_id
+            - environment
             - name
             - slug
             - description
@@ -30179,9 +30179,8 @@ components:
               format: uuid
             service_type:
               $ref: '#/components/schemas/ServiceTypeEnum'
-            environment_id:
-              type: string
-              format: uuid
+            environment:
+              $ref: '#/components/schemas/ReferenceObject'
             name:
               type: string
               description: name is case insensitive


### PR DESCRIPTION
## What changed

Replace the flat `environment_id` field in `AgenticWorkflowResponse` with an `environment` reference object.

## Why

Agentic Workflow creation responses should follow the same shape as other service creation endpoints and expose the environment identifier through `environment.id`. The previous change introduced a response shape inconsistent with the existing service schemas.

## Impact

API consumers can now access the environment identifier consistently through `environment.id`.

## Validation

- `git diff --check`
- YAML parsing with the project dependency
- Spectral lint attempted, but the remote Stoplight ruleset currently returns HTTP 404