### PR TITLE
feat(agentic-workflow): expose agentic workflow statuses in status schemas

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21807,6 +21807,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Status'
+        agentic_workflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/Status'
     EnvironmentStatusEventOriginEnum:
       type: string
       nullable: true
@@ -22481,6 +22485,10 @@ components:
           items:
             $ref: '#/components/schemas/Status'
         terraforms:
+          type: array
+          items:
+            $ref: '#/components/schemas/Status'
+        agentic_workflows:
           type: array
           items:
             $ref: '#/components/schemas/Status'

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -1057,7 +1057,12 @@ components:
       - helms
       - terraform
       - argocd_apps
+      - agentic_workflows
       properties:
+        agentic_workflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationStatusDto'
         applications:
           type: array
           items:


### PR DESCRIPTION
Core already returns agentic workflow statuses on /environment/{id}/statuses and /environment/{id}/statusesWithStages, but the schemas declared neither, so generated clients never surfaced them. Same story for the websocket gateway's /service/status payload.

agentic_workflows is left out of the required list on EnvironmentStatuses, unlike its six siblings. A required field would mean an older or rolled back core costs every service its deployment status, not just workflows; optional degrades to workflows having no deployment status.

websocket-openapi.yaml is generated from the gateway's utoipa types. The edit here matches what regeneration emits once EnvironmentStatusDto gains agentic_workflows: Vec<ApplicationStatusDto> as its last field: appended to required, first in the alphabetically sorted properties.