### PR TITLE
fix(audit-logs): add agentic workflow target type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24253,6 +24253,7 @@ components:
       type: string
       description: Type of the organization event
       enum:
+        - AGENTIC_WORKFLOW
         - APPLICATION
         - CLUSTER
         - CONTAINER


### PR DESCRIPTION
## Summary

Add `AGENTIC_WORKFLOW` to `OrganizationEventTargetType`.

The audit-log API already returns agentic workflow events, but the target type was missing from the OpenAPI enum. Generated clients therefore could not represent the runtime value, and consumers could crash when rendering these events.

## Testing

- YAML parsing: passed
- `git diff --check`: passed
- Spectral: could not run because the repository's remote Stoplight ruleset returns `404 Not Found`