### PR TITLE
feat(environment): expose read-only expires_at on the environment schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21605,6 +21605,15 @@ components:
             cluster_name:
               type: string
               format: string
+            expires_at:
+              type: string
+              format: date-time
+              nullable: true
+              readOnly: true
+              description: >-
+                Date after which the environment is automatically deleted. Null when the
+                environment never expires, which is the case for every environment except the
+                throwaway ones created for a single agentic workflow run.
     EnvironmentResponseList:
       type: object
       properties:


### PR DESCRIPTION
Environments cloned per agentic workflow run carry a TTL and are deleted automatically once it elapses. Surface that date so clients can show it.

Read-only: the API never accepts it as input.