### PR TITLE
feat(variable): add AGENTIC_WORKFLOW to variable scope enums

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22271,6 +22271,7 @@ components:
         - JOB
         - HELM
         - TERRAFORM
+        - AGENTIC_WORKFLOW
     APIVariableTypeEnum:
       type: string
       description: |
@@ -26255,6 +26256,7 @@ components:
         - JOB
         - HELM
         - TERRAFORM
+        - AGENTIC_WORKFLOW
     JobTypeEnum:
       type: string
       description: type of job


### PR DESCRIPTION
Agentic workflows can now own environment variables and secrets, so both the listing scope and the import service type accept them.

- APIVariableScopeEnum: used by GET/POST /variable and the import payload
- ServiceTypeForVariableEnum: used by POST /variable/import?service_type

Backend side: Qovery/q-core feat(agentic-workflow) support environment variables for agentic workflows.