### PR TITLE
feat(agentic-workflow): add MCP server associations

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30325,6 +30325,7 @@ components:
             - docker_fragment
             - enabled
             - mcp
+            - mcp_server_ids
             - outputs
             - model
             - project_repositories
@@ -30360,6 +30361,13 @@ components:
             mcp:
               type: string
               description: Raw JSON blob describing the MCP servers configured for this workflow
+            mcp_server_ids:
+              type: array
+              uniqueItems: true
+              items:
+                type: string
+                format: uuid
+              description: Organization MCP servers used by this workflow
             outputs:
               type: array
               items:
@@ -30416,6 +30424,14 @@ components:
               type: string
               default: ''
               description: Raw JSON blob describing the MCP servers configured for this workflow
+            mcp_server_ids:
+              type: array
+              uniqueItems: true
+              items:
+                type: string
+                format: uuid
+              default: []
+              description: Organization MCP servers used by this workflow
             outputs:
               type: array
               items:


### PR DESCRIPTION
## Summary

- Add `mcp_server_ids` to Agentic Workflow requests and responses.
- Default request values to an empty array for backward compatibility.
- Require unique UUID values and document their organization scope.

## Validation

- YAML parsing passed.
- `git diff --check` passed.
- Full Spectral validation is currently blocked because the repository's remote Stoplight ruleset returns `404 Not Found`.