### PR TITLE
feat(cluster): per-pool Karpenter spot_enabled, deprecate the global flag

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26762,6 +26762,21 @@ components:
           type: boolean
           x-stoplight:
             id: fuolcs5q8ncp8
+          deprecated: true
+          description: >-
+            Deprecated: use the per-pool `spot_enabled` fields on
+            `qovery_node_pools.default_override`, `qovery_node_pools.stable_override` and
+            `qovery_node_pools.cronjob_override` instead.
+
+
+            On read, this is a derived value: it is recomputed on every write as the logical OR of
+            the per-pool `spot_enabled` fields (default, stable and cronjob node pools).
+
+
+            On write, it is only honoured for legacy clients: when none of the per-pool
+            `spot_enabled` fields are present in the request, this value is applied to all node
+            pools, including the stable one. As soon as the per-pool fields are present they take
+            precedence and this value is ignored.
         disk_size_in_gib:
           type: integer
         disk_iops:
@@ -27392,6 +27407,12 @@ components:
           $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
         limits:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
+        spot_enabled:
+          type: boolean
+          description: >-
+            Whether this node pool runs on spot instances. When absent from a request, the
+            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
+            (legacy behavior).
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27454,6 +27475,12 @@ components:
           $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
         limits:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
+        spot_enabled:
+          type: boolean
+          description: >-
+            Whether this node pool runs on spot instances. When absent from a request, the
+            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
+            (legacy behavior).
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27465,6 +27492,12 @@ components:
       properties:
         limits:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
+        spot_enabled:
+          type: boolean
+          description: >-
+            Whether this node pool runs on spot instances. When absent from a request, the
+            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
+            (legacy behavior).
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26770,7 +26770,8 @@ components:
 
 
             On read, this is a derived value: it is recomputed on every write as the logical OR of
-            the per-pool `spot_enabled` fields (default, stable and cronjob node pools).
+            the per-pool `spot_enabled` fields of the node pools present (the default and stable
+            node pools, plus the cronjob node pool only while its `cronjob_override` block exists).
 
 
             On write, it is only honoured for legacy clients: when none of the per-pool
@@ -27409,10 +27410,22 @@ components:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
         spot_enabled:
           type: boolean
+          nullable: true
           description: >-
             Whether this node pool runs on spot instances. When absent from a request, the
             deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
             (legacy behavior).
+
+
+            On read, only a value that genuinely deviates from the deprecated top-level
+            `spot_enabled` is surfaced, so responses stay as close as possible to their
+            pre-migration shape. When this pool resolves to the global value this field comes back
+            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
+            deprecated top-level `spot_enabled`, so no information is lost.
+
+
+            The `stable_override` block itself is never omitted from the response; only this
+            field's value is affected.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27477,10 +27490,24 @@ components:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
         spot_enabled:
           type: boolean
+          nullable: true
           description: >-
             Whether this node pool runs on spot instances. When absent from a request, the
             deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
             (legacy behavior).
+
+
+            On read, only a value that genuinely deviates from the deprecated top-level
+            `spot_enabled` is surfaced, so responses stay as close as possible to their
+            pre-migration shape. When this pool resolves to the global value this field comes back
+            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
+            deprecated top-level `spot_enabled`, so no information is lost.
+
+
+            The `cronjob_override` block itself is never omitted from the response, because its
+            presence is what enables the cronjob node pool. For the same reason this field is only
+            meaningful while that pool is enabled: a disabled cronjob node pool has no stored spot
+            preference.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27494,10 +27521,24 @@ components:
           $ref: '#/components/schemas/KarpenterNodePoolLimits'
         spot_enabled:
           type: boolean
+          nullable: true
           description: >-
             Whether this node pool runs on spot instances. When absent from a request, the
             deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
             (legacy behavior).
+
+
+            On read, only a value that genuinely deviates from the deprecated top-level
+            `spot_enabled` is surfaced, so responses stay as close as possible to their
+            pre-migration shape. When this pool resolves to the global value this field comes back
+            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
+            deprecated top-level `spot_enabled`, so no information is lost.
+
+
+            `default_override` is the only override block that can be omitted entirely: when this
+            field is nulled and the block carries neither `limits` nor `consolidate_after`, the
+            whole block is dropped from the response. This restores the pre-migration wire shape
+            that existing clients, notably the Terraform provider, rely on.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27412,20 +27412,9 @@ components:
           type: boolean
           nullable: true
           description: >-
-            Whether this node pool runs on spot instances. When absent from a request, the
-            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
-            (legacy behavior).
-
-
-            On read, only a value that genuinely deviates from the deprecated top-level
-            `spot_enabled` is surfaced, so responses stay as close as possible to their
-            pre-migration shape. When this pool resolves to the global value this field comes back
-            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
-            deprecated top-level `spot_enabled`, so no information is lost.
-
-
-            The `stable_override` block itself is never omitted from the response; only this
-            field's value is affected.
+            Whether this node pool runs on spot instances. `null` or absent means the pool
+            inherits the deprecated top-level `spot_enabled`: on write that value applies to this
+            pool, on read only a deviating value is surfaced.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27492,22 +27481,10 @@ components:
           type: boolean
           nullable: true
           description: >-
-            Whether this node pool runs on spot instances. When absent from a request, the
-            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
-            (legacy behavior).
-
-
-            On read, only a value that genuinely deviates from the deprecated top-level
-            `spot_enabled` is surfaced, so responses stay as close as possible to their
-            pre-migration shape. When this pool resolves to the global value this field comes back
-            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
-            deprecated top-level `spot_enabled`, so no information is lost.
-
-
-            The `cronjob_override` block itself is never omitted from the response, because its
-            presence is what enables the cronjob node pool. For the same reason this field is only
-            meaningful while that pool is enabled: a disabled cronjob node pool has no stored spot
-            preference.
+            Whether this node pool runs on spot instances. `null` or absent means the pool
+            inherits the deprecated top-level `spot_enabled`: on write that value applies to this
+            pool, on read only a deviating value is surfaced. Only meaningful while the cronjob
+            node pool is enabled — the presence of `cronjob_override` is what enables it.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
@@ -27523,22 +27500,10 @@ components:
           type: boolean
           nullable: true
           description: >-
-            Whether this node pool runs on spot instances. When absent from a request, the
-            deprecated top-level `spot_enabled` of the Karpenter parameters applies to this pool
-            (legacy behavior).
-
-
-            On read, only a value that genuinely deviates from the deprecated top-level
-            `spot_enabled` is surfaced, so responses stay as close as possible to their
-            pre-migration shape. When this pool resolves to the global value this field comes back
-            as `null`. Treat `null` and absent identically: in both cases the pool inherits the
-            deprecated top-level `spot_enabled`, so no information is lost.
-
-
-            `default_override` is the only override block that can be omitted entirely: when this
-            field is nulled and the block carries neither `limits` nor `consolidate_after`, the
-            whole block is dropped from the response. This restores the pre-migration wire shape
-            that existing clients, notably the Terraform provider, rely on.
+            Whether this node pool runs on spot instances. `null` or absent means the pool
+            inherits the deprecated top-level `spot_enabled`: on write that value applies to this
+            pool, on read only a deviating value is surfaced. `default_override` is omitted from a
+            response when it would carry nothing else.
         consolidate_after:
           type: string
           description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'


### PR DESCRIPTION
Implements [QOV-2156](https://qovery.atlassian.net/browse/QOV-2156): Karpenter spot becomes an explicit per-pool setting, per q-core ADR `0001-per-nodepool-spot-explicit-truth`.

The q-core side is already merged on `main` — `66669f67d` (model + resolution, MR 3821), `aa81deeda` (response view, MR 3829), `e56a14863` (backfill, MR 3822) — so this spec update can publish now. It unblocks the [CONSOLE] per-pool spot work (QOV-2157) and feeds the [TF PROVIDER] ticket (QOV-2158).

## Changes

**Three new per-pool fields.** `spot_enabled` (boolean, **nullable**, no schema default) on `KarpenterStableNodePoolOverride`, `KarpenterDefaultNodePoolOverride` and `KarpenterCronjobNodePoolOverride`, mirroring the existing `gpu_override.spot_enabled`.

Nullability is functional, not cosmetic: `KarpenterDomain.omittingMaterializedSpotEnabled()` returns `null` for a pool whose value equals the derived global, so non-nullable generated clients would fail to deserialize real responses. There is deliberately no `default: false` either — absence and `null` both carry meaning (inherit the global), and a schema default would tell client authors the opposite.

**Documented semantics on each per-pool field.**
- *Request*: when the per-pool field is absent, the deprecated top-level `spot_enabled` applies to that pool — including `stable` (legacy behavior, verified in the engine, which resolves `stable_override.spot_enabled.unwrap_or(global)` and has asserted spot capacity on every pool since 2024-10).
- *Response*: only a value that genuinely deviates from the global is surfaced; `null` and absent must be treated identically. The omission is lossless because a `null` resolves back to the same global flag.
- *Block omission*, scoped precisely to match the implementation: `default_override` is the only block that can be dropped entirely (when it carries no `limits`, no `consolidate_after` and no `spot_enabled`), which restores the pre-migration wire shape existing clients depend on. `stable_override` and `cronjob_override` are always kept — the latter because its presence is what enables the cronjob node pool, which is also why its `spot_enabled` is only meaningful while that pool is enabled.

**Global flag deprecated.** `ClusterFeatureKarpenterParameters.spot_enabled` gains `deprecated: true` and documents both directions: on read it is a derived value recomputed on every write as the OR over the pools that *exist* (counting cronjob only while its override block is present — not a flat OR of all three); on write it is honoured only for legacy clients sending no per-pool field. It stays in `required` and keeps its `x-stoplight` id, since it is always present in responses and dropping it would break existing generated clients.

`KarpenterGpuNodePoolOverride` is untouched: its `spot_enabled` predates this migration, keeps `default: false`, and is intentionally excluded from the derived OR.

## Validation

- **Spectral lint** (`spectral:oas` ruleset), HEAD baseline vs this branch: identical at 269 problems (4 errors, 265 warnings) — **zero new findings**. The 4 errors are pre-existing, unrelated `no-$ref-siblings`.
- **38 structural assertions** over the PyYAML-parsed spec: nullability, absence of defaults, `required` membership, description content per pool, block-omission scoping, and GPU-untouched invariants.
- Semantics cross-checked against the merged q-core implementation and the engine's Karpenter chart rendering rather than ticket text alone.

## Note for reviewers

`npm test` is broken in this repo independently of this PR: `.spectral.mjs` extends a Stoplight ruleset URL that now 404s, and no CI workflow runs it — which is why the 4 pre-existing errors went unnoticed. Linting here was done with Spectral's built-in ruleset. Worth a separate ticket to vendor the ruleset locally.


[QOV-2156]: https://qovery.atlassian.net/browse/QOV-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ