### PR TITLE
fix: generate MCP server IDs as arrays

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31057,7 +31057,6 @@ components:
               description: Raw JSON blob describing the MCP servers configured for this workflow
             mcp_server_ids:
               type: array
-              uniqueItems: true
               items:
                 type: string
                 format: uuid
@@ -31120,7 +31119,6 @@ components:
               description: Raw JSON blob describing the MCP servers configured for this workflow
             mcp_server_ids:
               type: array
-              uniqueItems: true
               items:
                 type: string
                 format: uuid


### PR DESCRIPTION
## Summary

- Remove `uniqueItems` from Agentic Workflow `mcp_server_ids` request and response schemas.
- Generate this JSON array as `Array<string>` instead of `Set<string>` in TypeScript clients.

## Why

The API sends and receives `mcp_server_ids` as a JSON array. Mapping it to `Set<string>` requires Console-specific casts and response normalization.

## Validation

- `git diff --check`
- Spectral could not run because the repository's remote Stoplight ruleset returns `404`.
- Client generation could not run locally because Java is unavailable.
