### PR TITLE
feat(agentic-workflow): expose workflow schedule

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30994,6 +30994,7 @@ components:
             - governance
             - resources
             - webhook
+            - schedule
           properties:
             id:
               type: string
@@ -31046,6 +31047,11 @@ components:
               $ref: '#/components/schemas/AgenticWorkflowResources'
             webhook:
               $ref: '#/components/schemas/AgenticWorkflowWebhook'
+            schedule:
+              allOf:
+                - $ref: '#/components/schemas/AgenticWorkflowScheduleResponse'
+              nullable: true
+              description: Cron schedule firing runs of this workflow. Null when the workflow is webhook-only.
             icon_uri:
               type: string
               format: uri
@@ -31110,6 +31116,13 @@ components:
               $ref: '#/components/schemas/AgenticWorkflowGovernance'
             resources:
               $ref: '#/components/schemas/AgenticWorkflowResources'
+            schedule:
+              allOf:
+                - $ref: '#/components/schemas/AgenticWorkflowScheduleRequest'
+              nullable: true
+              description: >-
+                Cron schedule firing runs of this workflow, on top of the webhook every workflow
+                already has. Omit it, or send null, for a webhook-only workflow.
     AgenticWorkflowGovernance:
       type: object
       required:
@@ -31227,6 +31240,44 @@ components:
       properties:
         url:
           type: string
+    AgenticWorkflowScheduleRequest:
+      type: object
+      required:
+        - cron_expression
+        - timezone
+      properties:
+        cron_expression:
+          type: string
+          description: >-
+            Five-field cron expression, the same syntax Kubernetes cron jobs accept. Rejected if it
+            fires more than once every 5 minutes, since each run deploys a full environment.
+          example: 0 8 * * 1-5
+        timezone:
+          type: string
+          description: tz database identifier the expression is evaluated in.
+          example: Europe/Paris
+    AgenticWorkflowScheduleResponse:
+      type: object
+      required:
+        - cron_expression
+        - timezone
+        - next_run_at
+      properties:
+        cron_expression:
+          type: string
+          example: 0 8 * * 1-5
+        timezone:
+          type: string
+          description: tz database identifier the expression is evaluated in.
+          example: Europe/Paris
+        next_run_at:
+          type: string
+          format: date-time
+          nullable: true
+          readOnly: true
+          description: >-
+            When the schedule fires next. Null while the workflow is disabled, since a disabled
+            workflow accumulates no occurrences.
   responses:
     '204':
       description: no content


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional cron scheduling to agentic workflows in the API spec. Workflows can define a `schedule` (cron expression and timezone) that fires runs on top of the existing webhook trigger, and the response exposes `next_run_at` for the next scheduled run. Schedules that fire more than once every 5 minutes are rejected, and `next_run_at` is null while the workflow is disabled.

<sup>Written for commit a841f6e3a27ae43ed7b37eacb8d3111ba107a169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

