### PR TITLE
feat(agentic-workflow): expose the run execution mode

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31007,6 +31007,7 @@ components:
             - resources
             - webhook
             - schedule
+            - execution_mode
           properties:
             id:
               type: string
@@ -31064,6 +31065,8 @@ components:
                 - $ref: '#/components/schemas/AgenticWorkflowScheduleResponse'
               nullable: true
               description: Cron schedule firing runs of this workflow. Null when the workflow is webhook-only.
+            execution_mode:
+              $ref: '#/components/schemas/AgenticWorkflowExecutionMode'
             icon_uri:
               type: string
               format: uri
@@ -31135,6 +31138,22 @@ components:
               description: >-
                 Cron schedule firing runs of this workflow, on top of the webhook every workflow
                 already has. Omit it, or send null, for a webhook-only workflow.
+            execution_mode:
+              allOf:
+                - $ref: '#/components/schemas/AgenticWorkflowExecutionMode'
+              default: IN_PLACE
+              description: >-
+                Where a run executes. Defaults to IN_PLACE, which deploys the workflow in the
+                environment it belongs to.
+    AgenticWorkflowExecutionMode:
+      type: string
+      description: >-
+        Where a run executes. IN_PLACE deploys the workflow in the environment it belongs to, and is
+        the default. CLONE_ENVIRONMENT gives each run a throwaway copy of the whole environment,
+        which is the only mode that isolates concurrent runs from each other.
+      enum:
+        - IN_PLACE
+        - CLONE_ENVIRONMENT
     AgenticWorkflowGovernance:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31139,18 +31139,14 @@ components:
                 Cron schedule firing runs of this workflow, on top of the webhook every workflow
                 already has. Omit it, or send null, for a webhook-only workflow.
             execution_mode:
-              allOf:
-                - $ref: '#/components/schemas/AgenticWorkflowExecutionMode'
-              default: IN_PLACE
-              description: >-
-                Where a run executes. Defaults to IN_PLACE, which deploys the workflow in the
-                environment it belongs to.
+              $ref: '#/components/schemas/AgenticWorkflowExecutionMode'
     AgenticWorkflowExecutionMode:
       type: string
       description: >-
         Where a run executes. IN_PLACE deploys the workflow in the environment it belongs to, and is
         the default. CLONE_ENVIRONMENT gives each run a throwaway copy of the whole environment,
         which is the only mode that isolates concurrent runs from each other.
+      default: IN_PLACE
       enum:
         - IN_PLACE
         - CLONE_ENVIRONMENT


### PR DESCRIPTION
execution_mode, IN_PLACE or CLONE_ENVIRONMENT, on the agentic workflow request and response. Defaults to IN_PLACE, which runs the workflow in the environment it belongs to; CLONE_ENVIRONMENT is the previous behaviour and the only mode that isolates concurrent runs.

Added to the response after service_type on purpose: the rust post-generation patch default_service_type.diff anchors a hunk on that property, and inserting above it shifts the generated line numbers and breaks the client build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `execution_mode` to agentic workflow requests and responses, letting callers choose between running in the workflow's own environment (`IN_PLACE`, the default) and a throwaway clone (`CLONE_ENVIRONMENT`). Existing behavior is preserved as the new field defaults to `IN_PLACE`; `CLONE_ENVIRONMENT` remains the only mode that isolates concurrent runs.

<sup>Written for commit a60719715529d8810f1f0c0c33879401d6b871fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

