### PR TITLE
feat(websocket): carry the reason a blueprint preview timed out

### DIFF
--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -731,10 +731,17 @@ components:
             enum:
             - cancelled
       - type: object
-        description: The preview did not complete in time.
+        description: |-
+          The preview did not complete in time. `message` names the step that ran out of time and
+          after how long, when the engine got far enough to report it; it is absent when nothing
+          did — the engine went quiet, or the gateway stopped waiting first.
         required:
         - type
         properties:
+          message:
+            type:
+            - string
+            - 'null'
           type:
             type: string
             enum:


### PR DESCRIPTION
What:
The `timeout` variant of `BlueprintPreviewResult` gains an optional nullable `message`.

Why:
The engine now bounds a preview's terraform run and reports hitting that bound with the step that ran out of time and after how long; q-core forwards it on the timeout frame rather than as an error. Without the field in the schema, no generated client can read it.

Notes:
Optional and nullable because two producers have no reason to give — the gateway's own timeout frames, and the console's client-side watchdog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional nullable `message` field to the `timeout` variant of `BlueprintPreviewResult` in the WebSocket OpenAPI schema so generated clients can read why a preview timed out. Previously the timeout frame carried no reason; now the engine can report the step that ran out of time and after how long, while still allowing the field to be absent when the engine went quiet or the gateway stopped waiting first.

<sup>Written for commit 72e4506f93b6d1c2128b55913a08f1d62d3c0789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

