### PR TITLE
feat(websocket): report blueprint dispatch failures

### DIFF
--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -715,7 +715,6 @@ components:
         required:
         - blueprint_id
         - status
-        - error_message
         - type
         properties:
           blueprint_id:
@@ -728,7 +727,9 @@ components:
             type:
             - string
             - 'null'
-            description: The engine's failure reason; null when it reported none.
+            description: |-
+              The engine's failure reason. The key is always present; its value is null when the
+              engine gave no reason, so a client must branch on null, not on absence.
           type:
             type: string
             enum:

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -740,10 +740,13 @@ components:
     BlueprintDispatchFailureStatus:
       type: string
       description: |-
-        How a failed dispatch ended. This set is closed by `translateStatus` in q-core's
-        `BlueprintEngineDeploymentProcessor` — not by the wider `DeploymentStatusType` it draws
-        from, whose other members are unreachable on this frame. A new case in `translateStatus`
-        widens the wire set with no signal in this repo.
+        Status q-core settled on for a failed dispatch — a `DeploymentStatusType` serialized as its
+        Kotlin constant name, so SCREAMING_SNAKE and *not* affected by q-core's snake_case property
+        naming strategy.
+
+        Narrower than `DeploymentStatusType`'s 28 values: q-core publishes a failure only for a terminal
+        engine step whose translated status is not RUNNING, and `BlueprintEngineDeploymentProcessor`'s
+        `translateStatus` can only reach these three there. Widen this if that mapping grows a case.
       enum:
       - FAILED
       - INTERNAL_ERROR

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -739,6 +739,11 @@ components:
         field selects the variant.
     BlueprintDispatchFailureStatus:
       type: string
+      description: |-
+        How a failed dispatch ended. This set is closed by `translateStatus` in q-core's
+        `BlueprintEngineDeploymentProcessor` — not by the wider `DeploymentStatusType` it draws
+        from, whose other members are unreachable on this frame. A new case in `translateStatus`
+        widens the wire set with no signal in this repo.
       enum:
       - FAILED
       - INTERNAL_ERROR

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -735,8 +735,16 @@ components:
             enum:
             - failed
       description: |-
-        One blueprint dispatch event. The stream emits these until the connection closes. The `type`
+        One blueprint dispatch outcome. The stream emits these until the connection closes; the `type`
         field selects the variant.
+
+        There is no upper bound on time-to-frame, and clients must not assume one. q-core aborts a
+        dispatch after 10 minutes of engine *silence*, not on total duration, so a provision that keeps
+        logging — a large Terraform apply, an RDS creation — legitimately runs far longer, and one that
+        logs indefinitely without reaching a terminal step yields no frame at all. Elapsed time is
+        therefore not evidence of an outcome: a client that waits N minutes and then reports failure is
+        inventing one. Bound the wait if you need to, but resolve it against the blueprint API rather
+        than from the timeout.
     BlueprintDispatchFailureStatus:
       type: string
       description: |-

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -747,6 +747,11 @@ components:
         Narrower than `DeploymentStatusType`'s 28 values: q-core publishes a failure only for a terminal
         engine step whose translated status is not RUNNING, and `BlueprintEngineDeploymentProcessor`'s
         `translateStatus` can only reach these three there. Widen this if that mapping grows a case.
+
+        `FAILED` and `CANCELED` are engine-reported, translated from the `DeployedError` and `Cancelled`
+        steps. `INTERNAL_ERROR` is not: the engine's `BlueprintStep` has no `GlobalError` variant, so it
+        can only come from q-core itself — a lifecycle exception, or the 10-minute engine-silence abort.
+        Don't expect engine logs to explain an `INTERNAL_ERROR`.
       enum:
       - FAILED
       - INTERNAL_ERROR

--- a/websocket/websocket-openapi.yaml
+++ b/websocket/websocket-openapi.yaml
@@ -12,6 +12,45 @@ info:
 servers:
 - url: wss://ws.qovery.com
 paths:
+  /blueprint/dispatch:
+    get:
+      tags:
+      - blueprint_dispatch
+      operationId: handle_blueprint_dispatch_request
+      parameters:
+      - name: organization
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: cluster
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          - 'null'
+          format: uuid
+      - name: project
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: environment
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Stream of blueprint dispatch events, discriminated on `type`. One frame per event; the connection stays open.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlueprintDispatchEvent'
   /blueprint/preview:
     get:
       tags:
@@ -48,45 +87,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlueprintPreviewResult'
-  /blueprint/service-created:
-    get:
-      tags:
-      - blueprint_service
-      operationId: handle_blueprint_service_created_request
-      parameters:
-      - name: organization
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: cluster
-        in: path
-        required: true
-        schema:
-          type:
-          - string
-          - 'null'
-          format: uuid
-      - name: project
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: environment
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      responses:
-        '200':
-          description: Stream of blueprint service-created events. One frame per event; the connection stays open.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlueprintServiceCreatedEvent'
   /cluster/metrics:
     get:
       tags:
@@ -692,6 +692,56 @@ components:
             $ref: '#/components/schemas/PodStatusDto'
         state:
           $ref: '#/components/schemas/ServiceStateDto'
+    BlueprintDispatchEvent:
+      oneOf:
+      - type: object
+        description: The blueprint's service was created.
+        required:
+        - blueprint_id
+        - type
+        properties:
+          blueprint_id:
+            type: string
+            format: uuid
+            description: Id of the blueprint whose service was created.
+          type:
+            type: string
+            enum:
+            - created
+      - type: object
+        description: |-
+          The dispatch failed. `status` says how it ended and `error_message` carries the reason the
+          engine gave, when it gave one.
+        required:
+        - blueprint_id
+        - status
+        - error_message
+        - type
+        properties:
+          blueprint_id:
+            type: string
+            format: uuid
+            description: Id of the blueprint that failed to dispatch.
+          status:
+            $ref: '#/components/schemas/BlueprintDispatchFailureStatus'
+          error_message:
+            type:
+            - string
+            - 'null'
+            description: The engine's failure reason; null when it reported none.
+          type:
+            type: string
+            enum:
+            - failed
+      description: |-
+        One blueprint dispatch event. The stream emits these until the connection closes. The `type`
+        field selects the variant.
+    BlueprintDispatchFailureStatus:
+      type: string
+      enum:
+      - FAILED
+      - INTERNAL_ERROR
+      - CANCELED
     BlueprintPreviewResult:
       oneOf:
       - type: object
@@ -749,16 +799,6 @@ components:
       description: |-
         Final result of a blueprint update preview. Exactly one frame is sent, then the connection
         closes. The `type` field selects the variant.
-    BlueprintServiceCreatedEvent:
-      type: object
-      description: One blueprint service-created event. The stream emits these until the connection closes.
-      required:
-      - blueprint_id
-      properties:
-        blueprint_id:
-          type: string
-          format: uuid
-          description: Id of the blueprint whose service was created.
     CertificateStatusDto:
       type: object
       required:


### PR DESCRIPTION
#### Why
A blueprint dispatch that fails emits nothing on `/blueprint/service-created`, which only ever reports success. The console keeps waiting, then wrongly tells the user the blueprint was created. QOV-2213.

#### What
The channel becomes `/blueprint/dispatch` and its frame is now a union on `type`:

- `created` — `blueprint_id`, as before.
- `failed` — `blueprint_id`, `status` (`FAILED`, `INTERNAL_ERROR`, `CANCELED`) and `error_message`, nullable, carrying the reason the engine gave.

A client can now tell a failed dispatch from a slow one.

#### Notes
Blueprints are pre-launch, so this replaces the old route and schema outright rather than deprecating them. q-core and websocket-gateway ship the matching frame in parallel; nothing depends on this spec landing first.

**Time-to-frame has no upper bound, and the schema says so.** This is the part most likely to be misread. q-core's 10-minute abort counts engine *silence*, not total duration — a provision that keeps logging (a large Terraform apply, an RDS creation) legitimately runs far longer, and one that logs indefinitely without reaching a terminal step yields no frame at all. So elapsed time is not evidence of an outcome, and a client that waits N minutes and then reports failure is inventing one. Publishing 10 minutes as a guarantee would have been worse than publishing nothing: it reads authoritative and reproduces QOV-2213 with the sign flipped. Clients may bound the wait, but must resolve it against the blueprint API rather than from the timeout.

This file is a checked-in snapshot of websocket-gateway's utoipa output, so it follows what the generator emits rather than what reads best here. Three consequences worth knowing when reviewing:

- **`error_message` is nullable and not in `required`.** q-core's mapper emits the key with a null value when the engine gave no reason, so the key is always present — but utoipa renders `Option<String>` as nullable-and-not-required, and marking it required would be reverted on the next regeneration. It would also have been the only nullable-and-required field among 45 in this spec. Clients must branch on a null value, not on the key being absent; a truthiness check misfires on both `null` and `""`.
- **`oneOf` with a per-variant `type` enum, no `discriminator` keyword** — matching `BlueprintPreviewResult` in the same file.
- **New path and schemas sit in alphabetical position**, which is why the paths diff looks larger than the change.

`status` is a closed set of three, not the full `DeploymentStatusType`. The only source of the published status is `translateStatus` in q-core's `BlueprintEngineDeploymentProcessor`, which maps every other final step to null (no frame) or to `RUNNING` (excluded by the publish guard), and whose `Cancelled` passthrough is bounded by `isErrorState()` to the same three. `FAILED` and `CANCELED` are engine-reported; `INTERNAL_ERROR` is not — the engine's `BlueprintStep` has no `GlobalError` variant, so it can only originate from q-core's own lifecycle-exception catch or its engine-silence abort. Anyone debugging an `INTERNAL_ERROR` should not expect engine logs to explain it, and on the silence path `error_message` is null by construction.

**Where the deciding facts live.** Every constraint above is enforced in a repo this one cannot see, so the schema descriptions name the sources rather than restating their conclusions — a conclusion goes stale silently, a pointer stays checkable:

| Constraint | Source |
|---|---|
| snake_case wire names (Kotlin declares `blueprintId`/`errorMessage`) | `RedisPubSubService.kt`, `PropertyNamingStrategies.SNAKE_CASE` on the companion-object mapper |
| `error_message` present-but-null | same mapper, no `NON_NULL` inclusion configured |
| the three-value `status` set | `translateStatus` in `BlueprintEngineDeploymentProcessor` |
| `INTERNAL_ERROR` is not engine-reported | `lib-engine/src/events/io/blueprint_step.rs` |
| no upper bound on time-to-frame | `STATUS_MESSAGE_ABORT_AFTER_NO_MESSAGE_DURATION`, a per-message silence timeout; no outer deadline on `runLifecycle` |

That fourth row is a third repo — the engine — which bounds the value set without either service referencing it. I verified `BlueprintStep`'s ten variants against the engine's `origin/main`; the q-core traces are the gateway session's, against unmerged branch `ao/q-core-2/blueprint-dispatch-failure-event`, and are not independently verified here.

Field-by-field match against the gateway's generated schema at `cf294a21`: `required`, the `status` `$ref`, `error_message`'s type, the enum members, and both descriptions taken verbatim.

Validation: `npm test` is `spectral lint openapi.yaml` and does not cover this file — the websocket spec is only consumed by the `generate-clients` workflow, which never lints it. Linted manually instead: the repo's `.spectral.mjs` ruleset URL 404s, so I used the stock `oas` ruleset and compared against `main`. Identical finding set (70 errors, 29 warnings) once the route rename is mapped; the findings on the new route (`path-params`, `operation-description`, `operation-tag-defined`) are the same spec-wide patterns `/blueprint/preview` already trips. Also verified the spec parses and no `$ref` dangles.