### PR TITLE
fix(qov-2153) Add hint for secret manager access parameter

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -270,6 +270,9 @@ x-tagGroups:
   - name: Blueprint
     tags:
       - Blueprint Main Calls
+  - name: Cluster
+    tags:
+      - Secret Manager Access
 servers:
   - url: 'https://api.qovery.com'
 paths:
@@ -15512,7 +15515,8 @@ components:
     secretManagerAccessId:
       name: secretManagerAccessId
       in: path
-      description: Secret Manager Access ID
+      description: |
+        Secret Manager Access Id - Use the endpoint [`GET /organization/{organizationId}/cluster`](#operation/listOrganizationCluster) to retrieve your secret manager access
       required: true
       schema:
         type: string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a hint to the `secretManagerAccessId` parameter so API users know how to retrieve the value.

- Describes how to get the secret manager access ID via the `GET /organization/{organizationId}/cluster` endpoint.
- Adds the Cluster tag group to the OpenAPI spec for better API documentation organization.

<sup>Written for commit 9fcb52f9bec0eca103879260354cdba395a972e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

