### PR TITLE
feat: add diaplyName and primaryCategory for service catalog

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16045,10 +16045,12 @@ components:
       type: object
       required:
         - name
+        - displayName
         - kind
         - description
         - icon
         - categories
+        - primaryCategory
         - provider
         - serviceFamily
         - majorVersions
@@ -16058,7 +16060,7 @@ components:
           example: aws-rds-postgresql
         displayName:
           type: string
-          description: Customer-facing name for the blueprint. Consumers should fall back to `name` when omitted.
+          description: Customer-facing name for the blueprint.
           example: Amazon RDS for PostgreSQL
         kind:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16056,6 +16056,10 @@ components:
         name:
           type: string
           example: aws-rds-postgresql
+        displayName:
+          type: string
+          description: Customer-facing name for the blueprint. Consumers should fall back to `name` when omitted.
+          example: Amazon RDS for PostgreSQL
         kind:
           type: string
           example: ServiceBlueprint
@@ -16069,6 +16073,10 @@ components:
           type: array
           items:
             type: string
+        primaryCategory:
+          type: string
+          description: Customer-facing category used to group blueprints in the service catalog.
+          example: Databases & Caches
         provider:
           type: string
           example: aws


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `displayName` and `primaryCategory` as required fields to the service catalog blueprint schema, so consumers can show customer-facing names and categories.

- Both fields are now required; consumers should fall back to `name` when `displayName` is omitted.

<sup>Written for commit 28e40d522f4fb4ce2f29088b7a7f4e919d3778b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

