### PR TITLE
fix: remove unused controller version from operator status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19846,9 +19846,6 @@ components:
             Display version reported by the Operator. For the POC version-reporting heartbeat, the
             official chart sets this to the exact installed image tag. Legacy Operators can report
             opaque build metadata instead.
-        controller_version:
-          type: string
-          nullable: true
         request_schema_version:
           type: string
           nullable: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the unused `controller_version` field from the operator status OpenAPI schema so the API contract matches the fields the Operator reports.

<sup>Written for commit b02bd1adc9bc31506c194013e6b8956707725381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

