### PR TITLE
feat(agentic-workflow): add lineage run history API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14089,24 +14089,39 @@ paths:
       parameters:
         - $ref: '#/components/parameters/agenticWorkflowId'
         - in: query
+          name: page
+          description: >-
+            Page number, starting at 1. Increment this value to retrieve subsequent pages of
+            run history, keeping pageSize and filters unchanged.
+          required: false
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - in: query
           name: pageSize
-          description: The number of runs to return in the current page
+          description: The number of runs to return in the current page. Must be greater than or equal to 1.
+          required: false
           schema:
             type: number
             nullable: true
             default: 20
+            minimum: 1
         - in: query
           name: status
           description: Filter runs by status. When omitted, all statuses are included.
           required: false
           schema:
-            $ref: '#/components/schemas/AgenticWorkflowRunStatusEnum'
+            $ref: '#/components/schemas/AgenticWorkflowRunStatus'
         - in: query
-          name: execution_mode
+          name: executionMode
           description: Filter runs by execution mode. When omitted, both execution modes are included.
           required: false
           schema:
-            $ref: '#/components/schemas/AgenticWorkflowRunExecutionModeEnum'
+            type: string
+            enum:
+              - IN_PLACE
+              - CLONE_ENVIRONMENT
         - in: query
           name: includeNonTriggerTargets
           description: >-
@@ -31587,9 +31602,9 @@ components:
             environment's ID. This is not the engine execution ID with an epoch-seconds suffix.
             Null when no deployment was created, such as a launch failure.
         execution_mode:
-          $ref: '#/components/schemas/AgenticWorkflowRunExecutionModeEnum'
+          $ref: '#/components/schemas/AgenticWorkflowExecutionMode'
         trigger:
-          $ref: '#/components/schemas/AgenticWorkflowRunTriggerEnum'
+          $ref: '#/components/schemas/AgenticWorkflowRunTrigger'
         run_group_id:
           type: string
           format: uuid
@@ -31605,7 +31620,7 @@ components:
             workflow triggered a CLONE_ENVIRONMENT batch. Runs with false are excluded from the
             listing unless includeNonTriggerTargets is true.
         status:
-          $ref: '#/components/schemas/AgenticWorkflowRunStatusEnum'
+          $ref: '#/components/schemas/AgenticWorkflowRunStatus'
         schedule_cron:
           type: string
           nullable: true
@@ -31657,7 +31672,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/AgenticWorkflowRun'
-    AgenticWorkflowRunStatusEnum:
+    AgenticWorkflowRunStatus:
       type: string
       description: Run lifecycle status. COMPLETED, FAILED and CANCELLED are terminal and are never rewritten.
       enum:
@@ -31666,16 +31681,7 @@ components:
         - COMPLETED
         - FAILED
         - CANCELLED
-    AgenticWorkflowRunExecutionModeEnum:
-      type: string
-      description: >-
-        Where the run executes. IN_PLACE uses the workflow's environment. CLONE_ENVIRONMENT
-        clones the environment and deploys every agentic workflow in it. This run-history enum
-        has no default; omitting the execution_mode query parameter includes both modes.
-      enum:
-        - IN_PLACE
-        - CLONE_ENVIRONMENT
-    AgenticWorkflowRunTriggerEnum:
+    AgenticWorkflowRunTrigger:
       type: string
       description: >-
         What triggered the run, independently of its execution mode. MANUAL is reserved for

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14064,6 +14064,74 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+  '/agenticWorkflow/{agenticWorkflowId}/runHistory':
+    get:
+      summary: List agentic workflow runs
+      description: >-
+        Returns run history across the workflow's whole clone lineage. agenticWorkflowId accepts
+        any workflow ID in the lineage, including a clone's ID, and is resolved to root_workflow_id
+        before querying. Run history is retained for 30 days; runs from before history recording
+        was introduced are not backfilled.
+
+        A CLONE_ENVIRONMENT event clones the environment and deploys every agentic workflow in it,
+        not only the workflow that triggered the event. Every deployed workflow has a run recorded.
+        run_group_id groups the runs in that batch, and is_trigger_target identifies the workflow
+        that actually triggered it. By default, only runs with is_trigger_target = true are returned.
+        Set includeNonTriggerTargets to true to also include runs in this lineage that were deployed
+        because another workflow triggered a clone batch.
+
+        Run records outlive their environments. Cloned environments have a 3-day TTL, so environment_id
+        may refer to a deleted environment and consumers must not assume it can still be resolved.
+        workflow_name, environment_name, environment_mode, prompt, schedule_cron and schedule_timezone
+        are snapshots taken when the run was triggered. Later renames or configuration changes do not
+        alter historical runs.
+      operationId: listAgenticWorkflowRunHistory
+      parameters:
+        - $ref: '#/components/parameters/agenticWorkflowId'
+        - in: query
+          name: pageSize
+          description: The number of runs to return in the current page
+          schema:
+            type: number
+            nullable: true
+            default: 20
+        - in: query
+          name: status
+          description: Filter runs by status. When omitted, all statuses are included.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AgenticWorkflowRunStatusEnum'
+        - in: query
+          name: execution_mode
+          description: Filter runs by execution mode. When omitted, both execution modes are included.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AgenticWorkflowRunExecutionModeEnum'
+        - in: query
+          name: includeNonTriggerTargets
+          description: >-
+            When false (the default), return only runs with is_trigger_target = true. When true,
+            also include runs in this lineage that were deployed as part of another workflow's
+            CLONE_ENVIRONMENT batch.
+          required: false
+          schema:
+            type: boolean
+            default: false
+      tags:
+        - Agentic Workflows
+      responses:
+        '200':
+          description: List run history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgenticWorkflowRunPaginatedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   '/terraform/{terraformId}/advancedSettings':
     get:
       summary: Get Advanced settings
@@ -31432,6 +31500,190 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgenticWorkflowResponse'
+    AgenticWorkflowRun:
+      type: object
+      description: >-
+        A run retained for 30 days, even after its environment is deleted. Names, environment mode,
+        prompt and schedule are snapshots captured when the run was triggered, not live workflow
+        or environment values.
+      required:
+        - id
+        - root_workflow_id
+        - workflow_id
+        - workflow_name
+        - organization_id
+        - project_id
+        - cluster_id
+        - environment_id
+        - environment_name
+        - environment_mode
+        - source_environment_id
+        - deployment_id
+        - execution_mode
+        - trigger
+        - run_group_id
+        - is_trigger_target
+        - status
+        - schedule_cron
+        - schedule_timezone
+        - prompt
+        - error_code
+        - error_message
+        - created_at
+        - started_at
+        - finished_at
+        - duration_ms
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Run ID.
+        root_workflow_id:
+          type: string
+          format: uuid
+          description: ID of the original workflow anchoring the whole clone lineage.
+        workflow_id:
+          type: string
+          format: uuid
+          description: ID of the concrete workflow that executed; for clone runs, this is the clone's ID.
+        workflow_name:
+          type: string
+          description: Workflow name captured when the run was triggered; later renames do not change it.
+        organization_id:
+          type: string
+          format: uuid
+        project_id:
+          type: string
+          format: uuid
+        cluster_id:
+          type: string
+          format: uuid
+          description: ID of the cluster where the run executes.
+        environment_id:
+          type: string
+          format: uuid
+          description: >-
+            ID of the execution environment; for clone runs, this is the cloned environment's ID.
+            It may refer to an environment that has since been deleted. Cloned environments have
+            a 3-day TTL, while run records are retained for 30 days. Consumers must not assume
+            the environment can still be resolved.
+        environment_name:
+          type: string
+          description: Environment name captured when the run was triggered; later renames do not change it.
+        environment_mode:
+          allOf:
+            - $ref: '#/components/schemas/EnvironmentModeEnum'
+          description: Snapshot of the execution environment's mode captured when the run was triggered.
+        source_environment_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: ID of the environment cloned from for CLONE_ENVIRONMENT; null for IN_PLACE.
+        deployment_id:
+          type: string
+          nullable: true
+          description: >-
+            Partial execution ID in the format {environment_id}-{version}, using the execution
+            environment's ID. This is not the engine execution ID with an epoch-seconds suffix.
+            Null when no deployment was created, such as a launch failure.
+        execution_mode:
+          $ref: '#/components/schemas/AgenticWorkflowRunExecutionModeEnum'
+        trigger:
+          $ref: '#/components/schemas/AgenticWorkflowRunTriggerEnum'
+        run_group_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Shared ID for every run in one CLONE_ENVIRONMENT batch. A batch deploys every agentic
+            workflow in the cloned environment, including workflows that did not trigger it.
+            Null for runs outside a clone batch.
+        is_trigger_target:
+          type: boolean
+          description: >-
+            True when this workflow triggered the run; false when it was deployed because another
+            workflow triggered a CLONE_ENVIRONMENT batch. Runs with false are excluded from the
+            listing unless includeNonTriggerTargets is true.
+        status:
+          $ref: '#/components/schemas/AgenticWorkflowRunStatusEnum'
+        schedule_cron:
+          type: string
+          nullable: true
+          description: Snapshot of the cron schedule when the run was triggered; null when no schedule was configured.
+        schedule_timezone:
+          type: string
+          nullable: true
+          description: Snapshot of the schedule timezone when the run was triggered; null when no schedule was configured.
+        prompt:
+          type: string
+          nullable: true
+          description: Prompt captured when the run was triggered; later prompt edits do not change it. Null when absent.
+        error_code:
+          type: string
+          nullable: true
+          description: Failure code, such as RATE_LIMITED, CLONE_FAILED or PREPARE_FAILED; null when absent.
+        error_message:
+          type: string
+          nullable: true
+          description: Failure details; null when absent.
+        created_at:
+          type: string
+          format: date-time
+          description: Time the run was recorded at trigger time, before it could fail to launch.
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Time the run entered RUNNING; null if it has not started.
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Time the run entered COMPLETED, FAILED or CANCELLED; null until it reaches a terminal status.
+        duration_ms:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            Derived elapsed time in milliseconds, calculated as finished_at minus started_at.
+            This value is not stored. Null when either timestamp is absent, including runs
+            that have not finished or failed before starting.
+    AgenticWorkflowRunPaginatedResponseList:
+      allOf:
+        - $ref: '#/components/schemas/PaginationData'
+        - type: object
+          properties:
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/AgenticWorkflowRun'
+    AgenticWorkflowRunStatusEnum:
+      type: string
+      description: Run lifecycle status. COMPLETED, FAILED and CANCELLED are terminal and are never rewritten.
+      enum:
+        - QUEUED
+        - RUNNING
+        - COMPLETED
+        - FAILED
+        - CANCELLED
+    AgenticWorkflowRunExecutionModeEnum:
+      type: string
+      description: >-
+        Where the run executes. IN_PLACE uses the workflow's environment. CLONE_ENVIRONMENT
+        clones the environment and deploys every agentic workflow in it. This run-history enum
+        has no default; omitting the execution_mode query parameter includes both modes.
+      enum:
+        - IN_PLACE
+        - CLONE_ENVIRONMENT
+    AgenticWorkflowRunTriggerEnum:
+      type: string
+      description: >-
+        What triggered the run, independently of its execution mode. MANUAL is reserved for
+        manual runs; no backend producer emits it yet.
+      enum:
+        - MANUAL
+        - SCHEDULE
+        - WEBHOOK
     AgenticWorkflowRequest:
       allOf:
         - required:


### PR DESCRIPTION
Agentic workflows now expose run history across their whole clone lineage, including runs whose short-lived environment has been deleted. The response records trigger-time snapshots and execution identifiers for 30 days.

**Draft: the repository Spectral gate remains blocked by pre-existing infrastructure.** `npm test` cannot fetch its configured remote ruleset (HTTP 404). Standard Spectral reports the same four `no-$ref-siblings` errors as the original base, with no new ERROR. OpenAPI validation, contract/collision checks, and the documentation build pass. Fresh Go, TypeScript Axios and Rust SDK builds also pass for this revision; exact results are recorded below.

## Final operation and parameters

**GET `/agenticWorkflow/{agenticWorkflowId}/runHistory`** — **`listAgenticWorkflowRunHistory`**.

The proposed path is unchanged. Naming, the shared path parameter, `Agentic Workflows` tag, inherited global bearer/API-key security, and shared 401/403/404 responses follow `listAgenticWorkflowDeploymentHistoryV2`. This is the first run-history operation, so it has no `V2` suffix.

Every query parameter explicitly has `required: false`:

| Query parameter | Schema/default | Meaning |
| --- | --- | --- |
| `page` | integer, minimum 1, default 1 | One-based page number; increment to retrieve subsequent pages, keeping pageSize and filters unchanged. |
| `pageSize` | number, nullable, minimum 1, default 20 | Number of runs per page; bounds match `listClusterDeploymentHistoryV2`. |
| `status` | `AgenticWorkflowRunStatus`, no default | Omitted means all statuses. |
| `executionMode` | inline string enum: IN_PLACE / CLONE_ENVIRONMENT, **no default** | Omitted means both execution modes. |
| `includeNonTriggerTargets` | boolean, default false | By default include only `is_trigger_target = true`; true also includes workflows swept along by another workflow's clone batch. |

**Conscious pagination deviation:** existing V2 deployment-history operations expose pageSize but no page-number query parameter, despite returning `PaginationData.page`. Run history adds `page` so SDK consumers can reach page 2 and later, rather than being limited to the first page. This is an accepted functional addition; existing sibling operations are unchanged.

Query names use camelCase, consistent with `eventType`, `targetType`, `forceEvent` and `deleteMode`. Response schema properties remain snake_case. The listing response composes the existing `PaginationData` and the existing `results` wrapper pattern through `allOf`.

## Schemas added and reused

The four new schemas are:

1. `AgenticWorkflowRun`
2. `AgenticWorkflowRunPaginatedResponseList`
3. `AgenticWorkflowRunStatus` — QUEUED | RUNNING | COMPLETED | FAILED | CANCELLED
4. `AgenticWorkflowRunTrigger` — MANUAL | SCHEDULE | WEBHOOK

`AgenticWorkflowRun.execution_mode` directly references the existing **`AgenticWorkflowExecutionMode`**, preserving the same generated response type used by `AgenticWorkflowResponse.execution_mode`. Its existing `default: IN_PLACE` is inert for this required, always-serialized response field.

The **query** uses an inline enum with the same two values and no default, following the inline enum precedent of `gpu` on `listAWSEKSInstanceType`. It deliberately does not reference the default-bearing shared schema: otherwise some generated SDKs could materialize IN_PLACE when callers omit the filter and hide clone runs. No separate run execution-mode component schema is added.

Also reuses `EnvironmentModeEnum` through `allOf`, `PaginationData`, `agenticWorkflowId`, and shared error responses. The two new lifecycle/trigger schema names omit the `Enum` suffix to match their immediate agentic schema family.

All **26 fields remain required**, including the nullable ones, as an accepted SDK typing decision. Names, environment mode, prompt and schedule are snapshots. Descriptions explain root resolution from any lineage member, all-workflow clone batches with grouping/target identity, 30-day retention, deleted environments with a 3-day clone TTL, partial deployment IDs, nullable derived int64 duration, and no backfill. `MANUAL` remains intentionally present despite having no producer yet. `Base` is not composed into the run object because it would expose an extra `updated_at` field outside the frozen field set.

## Scope and contract notes

- Only `openapi.yaml` is tracked in the diff. Against original base `1238c52deba3ce2e746f6093b075c110e7d5f42d`, the PR is **258 insertions and zero deletions**. All pre-existing document content is structurally identical. The review revision changes only this PR's additions, including removal of its duplicate execution-mode enum.
- No log field/link/operation, agent output/result/transcript field, or write operation is added.
- The top-level tag declaration is unchanged. Existing agentic operations use `Agentic Workflows` without globally declaring it; the new operation inherits the same standard-Spectral warning. Fixing the global declaration belongs outside this PR.
- **Unmet gate:** the configured `npm test` ruleset returns 404. The fallback's four existing errors also remain outside this additive scope. No rule or existing schema/operation was modified to suppress failures.
- All frozen wire fields and enum values are honored, with the approved page parameter, camelCase query naming, and shared response execution enum described above. Backend persistence/lifecycle/reaper work belongs to PR B. Do not merge this PR.

## Verification on this revision

File set: **`openapi.yaml`**. Tested content is committed as **`f85c42f7ec2c24945fcf195da714c4f196367cbd`**, compared against original base `1238c52deba3ce2e746f6093b075c110e7d5f42d`. These are lint/build/schema/fixture checks, not a collected unit-test suite.

Local dependencies were retained from the original verification (`npm ci --no-audit --no-fund`). The independent validator is installed only in ignored tooling, using `npm install --prefix node_modules/.cache/run-history-validator --no-package-lock --no-save --no-audit --no-fund @apidevtools/swagger-parser`. The full verification script is included below for reproduction; it is not part of the product diff.

### `node node_modules/.cache/check-agentic-run-history.cjs` — exit 0

```text
$ node node_modules/.cache/check-agentic-run-history.cjs
PASS: openapi.yaml parses with no YAML diagnostics or duplicate keys; OpenAPI version is 3.0.0
PASS: exactly one GET operation and four schemas added; no operationId/schema collisions; all existing document content unchanged
PASS: exact 26-field contract, required/nullable fields, fixed enums, shared execution/environment modes, and int64 duration
PASS: page defaults to 1; pageSize matches cluster-history bounds; camelCase query names are consistently optional; executionMode is inline with no default; shared wrapper/security/errors unchanged
PASS: @apidevtools/swagger-parser validates the entire document as OpenAPI 3.0.0
PASS: query fixtures accept omitted filters, page 2, and both modes; reject invalid page/pageSize/mode and the old execution_mode query name
PASS: response fixtures accept completed, launch-failure, swept-clone and MANUAL runs; reject unknown enums, missing cluster ID, invalid UUID and timestamp
PASS: standard Spectral comparison introduces no errors; baseline and final each have 4 pre-existing no-$ref-siblings errors; no OpenAPI schema errors
Inherited convention warning on new operation: operation-tag-defined: Operation tags must be defined in global tags.
Compared openapi.yaml against base commit 1238c52deba3ce2e746f6093b075c110e7d5f42d
```

### `npm test` — exit 2

Configured URL query token redacted below.

```text
$ npm test
> openapi-boilerplate@0.0.6 test
> spectral lint openapi.yaml

Error running Spectral!
Use --verbose flag to print the error stack.
Error #1: Could not load https://stoplight.io/api/v1/projects/cHJqOjI0NDY1MQ/spectral.js?branch_slug=main&token=<redacted> (imported by .spectral.mjs): Error fetching https://stoplight.io/api/v1/projects/cHJqOjI0NDY1MQ/spectral.js?branch_slug=main&token=<redacted> Not Found
```

### `npm test -- --ruleset node_modules/.cache/run-history-spectral.yaml --fail-severity error --display-only-failures` — exit 1

The ignored fallback ruleset contains exactly `extends: spectral:oas`; no rule is disabled. The contract script compares diagnostics by code, path and message against the base, allowing only the unchanged four baseline errors.

```text
$ npm test -- --ruleset node_modules/.cache/run-history-spectral.yaml --fail-severity error --display-only-failures
> openapi-boilerplate@0.0.6 test
> spectral lint openapi.yaml --ruleset node_modules/.cache/run-history-spectral.yaml --fail-severity error --display-only-failures


/Users/ffleureau/.worktrees/feat-agentic-sessions-history/qovery-openapi-spec/openapi.yaml
 12973:23  error  no-$ref-siblings  $ref must not be placed next to any other properties  paths./helm/{helmId}/listServices.get.responses[200].content.application/json.schema.type
 16278:21  error  no-$ref-siblings  $ref must not be placed next to any other properties  components.schemas.BlueprintCreateRequest.properties.spec_overrides.nullable
 17058:23  error  no-$ref-siblings  $ref must not be placed next to any other properties  components.schemas.BlueprintUpdateRequest.properties.variables.additionalProperties.nullable
 30665:24  error  no-$ref-siblings  $ref must not be placed next to any other properties  components.schemas.AlertTarget.properties.service.description

✖ 4 problems (4 errors, 0 warnings, 0 infos, 0 hints)
```

### `git diff --check && git diff --numstat 1238c52deba3ce2e746f6093b075c110e7d5f42d -- openapi.yaml` — exit 0

```text
$ git diff --check && git diff --numstat 1238c52deba3ce2e746f6093b075c110e7d5f42d -- openapi.yaml
258	0	openapi.yaml
```

### `npm run html` — exit 0

```text
$ npm run html
> openapi-boilerplate@0.0.6 html
> redoc-cli bundle openapi.yaml --output _build/index.html --options src/theme.json


   ┌───────────────────── DEPRECATED ─────────────────────┐
   │                                                      │
   │   This package is deprecated.                        │
   │                                                      │
   │   Use `npx @redocly/cli build-docs <api>` instead.   │
   │                                                      │
   └──────────────────────────────────────────────────────┘

Prerendering docs
Non-existing tag "Database Applications" is added to the group "Database"
Non-existing tag "Database Containers" is added to the group "Database"
Non-existing tag "Job Custom Domain" is added to the group "Job"

🎉 bundled successfully in: _build/index.html (8484 KiB) [⏱ 1.857s]
```

## SDK generation/build gates

[Generate API Clients run 34453072205](https://github.com/Qovery/qovery-openapi-spec/actions/runs/34453072205) passed for `f85c42f7ec2c24945fcf195da714c4f196367cbd`. Go, TypeScript Axios and Rust all passed generation and their existing post-generation build scripts, for both REST and the unchanged WebSocket spec. Those scripts run `go build`, `npm run build`, and `cargo build`/`cargo fmt`, respectively. Publishing was skipped for this pull request.

`gh run watch 34453072205 --exit-status --interval 30` exited 0. Final status confirmed with the following command (exit 0):

```text
$ gh run view 34453072205 --json headSha,status,conclusion,jobs --jq '{headSha,status,conclusion,jobs:[.jobs[]|{name,status,conclusion}]}'
{"conclusion":"success","headSha":"f85c42f7ec2c24945fcf195da714c4f196367cbd","jobs":[{"conclusion":"success","name":"generate (go, 7.6.0, qovery, master, SSH_DEPLOY_KEY_GO, SSH_DEPLOY_KEY_WS_GO)","status":"completed"},{"conclusion":"success","name":"generate (typescript-axios, 7.8.0, Qovery, main, SSH_DEPLOY_KEY_TYPESCRIPT_AXIOS, SSH_DEPLOY_KEY_...","status":"completed"},{"conclusion":"success","name":"generate (rust, 7.20.0, qovery, main, SSH_DEPLOY_KEY_RUST, SSH_DEPLOY_KEY_WS_RUST)","status":"completed"}],"status":"completed"}
```

The successful Go job still emits two `File name too long` annotations from the existing post-generation script against `model_helm_version_response.go`; they remain visible in the linked job log. The workflow also reports existing action deprecation warnings. No CI script was modified.




<details>
<summary>Reproduce the contract/schema/Spectral comparison</summary>

Save this as `node_modules/.cache/check-agentic-run-history.cjs` after the dependency commands above, then run `node node_modules/.cache/check-agentic-run-history.cjs`.

```javascript
const assert = require('node:assert/strict');
const fs = require('node:fs');
const { execFileSync } = require('node:child_process');
const { parseWithPointers } = require('@stoplight/yaml');
const { Spectral, Document } = require('@stoplight/spectral-core');
const { Yaml } = require('@stoplight/spectral-parsers');
const { oas } = require('@stoplight/spectral-rulesets');
const SwaggerParser = require('./run-history-validator/node_modules/@apidevtools/swagger-parser');
const Ajv = require('ajv');
const addFormats = require('ajv-formats');

const baseCommit = '1238c52deba3ce2e746f6093b075c110e7d5f42d';
const text = fs.readFileSync('openapi.yaml', 'utf8');
const baseText = execFileSync('git', ['show', `${baseCommit}:openapi.yaml`], { encoding: 'utf8' });
const parsed = parseWithPointers(text);
assert.deepEqual(parsed.diagnostics, []);
const spec = parsed.data;
const base = parseWithPointers(baseText).data;
assert.equal(spec.openapi, '3.0.0');
console.log('PASS: openapi.yaml parses with no YAML diagnostics or duplicate keys; OpenAPI version is 3.0.0');

const path = '/agenticWorkflow/{agenticWorkflowId}/runHistory';
const operationId = 'listAgenticWorkflowRunHistory';
const names = ['AgenticWorkflowRun', 'AgenticWorkflowRunPaginatedResponseList', 'AgenticWorkflowRunStatus', 'AgenticWorkflowRunTrigger'];
assert.ok(spec.paths[path]?.get, 'The run-history GET operation must exist');
assert.equal(spec.paths[path].get.operationId, operationId);
assert.deepEqual(Object.keys(spec.paths[path]), ['get']);
assert.ok(!base.paths[path]);
const ids = Object.values(spec.paths).flatMap(item => Object.values(item).filter(value => value?.operationId).map(value => value.operationId));
assert.equal(ids.length, new Set(ids).size);
const additions = Object.keys(spec.components.schemas).filter(name => !(name in base.components.schemas));
assert.deepEqual(additions.sort(), [...names].sort());
const restored = structuredClone(spec);
delete restored.paths[path];
for (const name of names) {
  assert.ok(!(name in base.components.schemas));
  delete restored.components.schemas[name];
}
assert.deepEqual(restored, base);
console.log('PASS: exactly one GET operation and four schemas added; no operationId/schema collisions; all existing document content unchanged');

const schemas = spec.components.schemas;
const run = schemas.AgenticWorkflowRun;
const fields = 'id root_workflow_id workflow_id workflow_name organization_id project_id cluster_id environment_id environment_name environment_mode source_environment_id deployment_id execution_mode trigger run_group_id is_trigger_target status schedule_cron schedule_timezone prompt error_code error_message created_at started_at finished_at duration_ms'.split(' ');
const nullable = 'source_environment_id deployment_id run_group_id schedule_cron schedule_timezone prompt error_code error_message started_at finished_at duration_ms'.split(' ');
assert.deepEqual(Object.keys(run.properties).sort(), [...fields].sort());
assert.deepEqual([...run.required].sort(), [...fields].sort());
assert.deepEqual(Object.keys(run.properties).filter(name => run.properties[name].nullable).sort(), [...nullable].sort());
assert.deepEqual(schemas.AgenticWorkflowRunStatus.enum, ['QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED']);
assert.deepEqual(schemas.AgenticWorkflowRunTrigger.enum, ['MANUAL', 'SCHEDULE', 'WEBHOOK']);
assert.deepEqual(run.properties.status, { $ref: '#/components/schemas/AgenticWorkflowRunStatus' });
assert.deepEqual(run.properties.trigger, { $ref: '#/components/schemas/AgenticWorkflowRunTrigger' });
assert.deepEqual(run.properties.execution_mode, { $ref: '#/components/schemas/AgenticWorkflowExecutionMode' });
assert.deepEqual(schemas.AgenticWorkflowExecutionMode.enum, ['IN_PLACE', 'CLONE_ENVIRONMENT']);
assert.deepEqual(run.properties.environment_mode.allOf, [{ $ref: '#/components/schemas/EnvironmentModeEnum' }]);
assert.equal(run.properties.duration_ms.type, 'integer');
assert.equal(run.properties.duration_ms.format, 'int64');
console.log('PASS: exact 26-field contract, required/nullable fields, fixed enums, shared execution/environment modes, and int64 duration');

const operation = spec.paths[path].get;
const history = base.paths['/agenticWorkflow/{agenticWorkflowId}/deploymentHistoryV2'].get;
assert.deepEqual(operation.tags, history.tags);
assert.deepEqual(operation.parameters[0], history.parameters[0]);
const queries = Object.fromEntries(operation.parameters.filter(parameter => parameter.in === 'query').map(parameter => [parameter.name, parameter]));
assert.deepEqual(Object.keys(queries), ['page', 'pageSize', 'status', 'executionMode', 'includeNonTriggerTargets']);
for (const query of Object.values(queries)) assert.equal(query.required, false);
assert.deepEqual(queries.page.schema, { type: 'integer', default: 1, minimum: 1 });
const clusterHistory = base.paths['/organization/{organizationId}/cluster/{clusterId}/deploymentHistoryV2'].get;
assert.deepEqual(queries.pageSize.schema, clusterHistory.parameters.find(parameter => parameter.name === 'pageSize').schema);
assert.deepEqual(queries.status.schema, { $ref: '#/components/schemas/AgenticWorkflowRunStatus' });
assert.deepEqual(queries.executionMode.schema, { type: 'string', enum: ['IN_PLACE', 'CLONE_ENVIRONMENT'] });
assert.equal(queries.includeNonTriggerTargets.schema.default, false);
assert.deepEqual(operation.security, history.security);
assert.deepEqual(Object.keys(operation.responses), Object.keys(history.responses));
for (const code of ['401', '403', '404']) assert.deepEqual(operation.responses[code], history.responses[code]);
const wrapper = structuredClone(schemas.DeploymentHistoryServicePaginatedResponseListV2);
delete wrapper['x-stoplight'];
wrapper.allOf[1].properties.results.items.$ref = '#/components/schemas/AgenticWorkflowRun';
assert.deepEqual(schemas.AgenticWorkflowRunPaginatedResponseList, wrapper);
console.log('PASS: page defaults to 1; pageSize matches cluster-history bounds; camelCase query names are consistently optional; executionMode is inline with no default; shared wrapper/security/errors unchanged');

(async () => {
  const validated = await SwaggerParser.validate('openapi.yaml');
  console.log(`PASS: @apidevtools/swagger-parser validates the entire document as OpenAPI ${validated.openapi}`);
  const ajv = new Ajv({ strict: false });
  addFormats(ajv);
  const validateQuery = ajv.compile({ type: 'object', properties: Object.fromEntries(Object.entries(queries).map(([name, parameter]) => [name, name === 'status' ? schemas.AgenticWorkflowRunStatus : parameter.schema])), additionalProperties: false });
  for (const query of [{}, { page: 2 }, { page: 3, pageSize: 50, executionMode: 'CLONE_ENVIRONMENT' }, { executionMode: 'IN_PLACE' }]) assert.ok(validateQuery(query), JSON.stringify(validateQuery.errors));
  for (const query of [{ page: 0 }, { page: 1.5 }, { pageSize: 0 }, { executionMode: 'UNKNOWN' }, { execution_mode: 'IN_PLACE' }]) assert.equal(validateQuery(query), false);
  const omitted = {};
  assert.ok(validateQuery(omitted));
  assert.deepEqual(omitted, {});
  console.log('PASS: query fixtures accept omitted filters, page 2, and both modes; reject invalid page/pageSize/mode and the old execution_mode query name');
  const validate = ajv.compile(validated.components.schemas.AgenticWorkflowRun);
  const fixture = {
    id: '00000000-0000-4000-8000-000000000001',
    root_workflow_id: '00000000-0000-4000-8000-000000000002',
    workflow_id: '00000000-0000-4000-8000-000000000002',
    workflow_name: 'Nightly audit',
    organization_id: '00000000-0000-4000-8000-000000000003',
    project_id: '00000000-0000-4000-8000-000000000004',
    cluster_id: '00000000-0000-4000-8000-000000000005',
    environment_id: '00000000-0000-4000-8000-000000000006',
    environment_name: 'production',
    environment_mode: 'PRODUCTION',
    source_environment_id: null,
    deployment_id: '00000000-0000-4000-8000-000000000006-42',
    execution_mode: 'IN_PLACE',
    trigger: 'SCHEDULE',
    run_group_id: null,
    is_trigger_target: true,
    status: 'COMPLETED',
    schedule_cron: '0 1 * * *',
    schedule_timezone: 'UTC',
    prompt: 'Audit dependencies',
    error_code: null,
    error_message: null,
    created_at: '2026-09-10T01:00:00Z',
    started_at: '2026-09-10T01:00:01Z',
    finished_at: '2026-09-10T01:00:03Z',
    duration_ms: 2000,
  };
  assert.ok(validate(fixture), JSON.stringify(validate.errors));
  const launchFailure = { ...fixture, trigger: 'WEBHOOK', status: 'FAILED' };
  for (const field of nullable) launchFailure[field] = null;
  launchFailure.error_code = 'RATE_LIMITED';
  assert.ok(validate(launchFailure), JSON.stringify(validate.errors));
  assert.ok(validate({ ...fixture, execution_mode: 'CLONE_ENVIRONMENT', environment_mode: 'PREVIEW', workflow_id: fixture.id, source_environment_id: fixture.environment_id, run_group_id: fixture.id, is_trigger_target: false }), JSON.stringify(validate.errors));
  assert.ok(validate({ ...fixture, trigger: 'MANUAL' }));
  for (const field of ['status', 'trigger', 'execution_mode', 'environment_mode']) assert.equal(validate({ ...fixture, [field]: 'UNKNOWN' }), false);
  const missingCluster = { ...fixture };
  delete missingCluster.cluster_id;
  assert.equal(validate(missingCluster), false);
  assert.equal(validate({ ...fixture, id: 'invalid-uuid' }), false);
  assert.equal(validate({ ...fixture, started_at: 'invalid-timestamp' }), false);
  console.log('PASS: response fixtures accept completed, launch-failure, swept-clone and MANUAL runs; reject unknown enums, missing cluster ID, invalid UUID and timestamp');

  const spectral = new Spectral();
  spectral.setRuleset(oas);
  const oldResults = await spectral.run(new Document(baseText, Yaml, 'base-openapi.yaml'));
  const newResults = await spectral.run(new Document(text, Yaml, 'openapi.yaml'));
  const signature = diagnostic => JSON.stringify([diagnostic.code, diagnostic.path, diagnostic.message]);
  const oldErrors = oldResults.filter(result => result.severity === 0);
  const newErrors = newResults.filter(result => result.severity === 0);
  assert.deepEqual(newErrors.map(signature).sort(), oldErrors.map(signature).sort());
  assert.equal(newResults.filter(result => result.code === 'oas3-schema').length, 0);
  const introduced = newResults.filter(result => !oldResults.some(old => signature(old) === signature(result)));
  assert.ok(introduced.every(result => result.code === 'operation-tag-defined' && result.path[0] === 'paths' && result.path[1] === path));
  console.log(`PASS: standard Spectral comparison introduces no errors; baseline and final each have ${newErrors.length} pre-existing no-$ref-siblings errors; no OpenAPI schema errors`);
  for (const warning of introduced) console.log(`Inherited convention warning on new operation: ${warning.code}: ${warning.message}`);
  console.log(`Compared openapi.yaml against base commit ${baseCommit}`);
})().catch(error => { console.error(error); process.exitCode = 1; });

```

</details>
