### PR TITLE
feat(mcp): document MCP connector scope and owner

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4939,7 +4939,7 @@ paths:
         '403':
           description: >-
             Editing an ORGANIZATION connector requires the MANAGE_INFRASTRUCTURE permission; a USER
-            connector can only be edited by its owner, so an organization admin is refused too.
+            connector can only be edited by its owner, so an organization admin is forbidden as well.
         '404':
           $ref: '#/components/responses/404'
         '409':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4888,7 +4888,7 @@ paths:
         '404':
           $ref: '#/components/responses/404'
         '409':
-          description: MCP server name is already taken in the organization
+          description: MCP server name is already taken for this scope owner in the organization
   '/mcpServer/{mcpServerId}':
     get:
       summary: Get an MCP server
@@ -4937,11 +4937,13 @@ paths:
         '401':
           $ref: '#/components/responses/401'
         '403':
-          $ref: '#/components/responses/403'
+          description: >-
+            Editing an ORGANIZATION connector requires the MANAGE_INFRASTRUCTURE permission; a USER
+            connector can only be edited by its owner, so an organization admin is refused too.
         '404':
           $ref: '#/components/responses/404'
         '409':
-          description: MCP server name is already taken in the organization
+          description: MCP server name is already taken for this scope owner in the organization
     delete:
       summary: Delete an MCP server
       description: Delete a remote MCP server configuration.
@@ -13741,7 +13743,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/AgenticWorkflowResponse'
         '400':
-          $ref: '#/components/responses/400'
+          description: >-
+            Invalid workflow configuration. Includes attaching an MCP connector that is personal
+            to another member, and attaching two connectors that share a name.
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -13901,7 +13905,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/AgenticWorkflowResponse'
         '400':
-          $ref: '#/components/responses/400'
+          description: >-
+            Invalid workflow configuration. Includes attaching an MCP connector that is personal
+            to another member, and attaching two connectors that share a name.
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -20653,6 +20659,14 @@ components:
               x-stoplight:
                 id: eaqm4swmqt9ty
               description: Required if kind is `AZURE_CR`.
+    McpServerScope:
+      type: string
+      enum:
+        - ORGANIZATION
+        - USER
+      description: >-
+        ORGANIZATION: usable by every member who can edit an agentic workflow.
+        USER: personal to the member who created it; only that member can attach or edit it.
     McpServerRequest:
       type: object
       required:
@@ -20662,7 +20676,7 @@ components:
         name:
           type: string
           minLength: 1
-          description: Unique MCP server name within the organization
+          description: MCP server name, unique per scope owner within the organization
         description:
           type: string
           default: ''
@@ -20678,6 +20692,14 @@ components:
           default: {}
           additionalProperties:
             type: string
+        scope:
+          allOf:
+            - $ref: '#/components/schemas/McpServerScope'
+          description: >-
+            Cannot be changed after creation. On create, omitting it means ORGANIZATION, which
+            requires the MANAGE_INFRASTRUCTURE permission; creating a USER connector requires
+            CREATE_PROJECT. On edit, omitting it leaves the connector's scope unchanged, and stating
+            a scope that differs from the connector's is refused with 400.
     McpServerResponse:
       allOf:
         - $ref: '#/components/schemas/Base'
@@ -20687,6 +20709,8 @@ components:
             - description
             - url
             - header_names
+            - scope
+            - attachable
             - updated_at
           properties:
             name:
@@ -20704,6 +20728,22 @@ components:
               uniqueItems: true
               items:
                 type: string
+            scope:
+              $ref: '#/components/schemas/McpServerScope'
+            owner_user_sub:
+              type: string
+              nullable: true
+              description: Identity of the owning member. Null for an ORGANIZATION connector.
+            owner_name:
+              type: string
+              nullable: true
+              description: Display name of the owning member. Null for an ORGANIZATION connector.
+            attachable:
+              type: boolean
+              description: >-
+                Whether the member making this request may attach the connector to an agentic
+                workflow. Computed per caller: an organization admin sees every USER connector but
+                can attach none of them, so a picker must use this rather than scope alone.
     McpServerResponseList:
       type: object
       required:
@@ -31263,7 +31303,9 @@ components:
               items:
                 type: string
                 format: uuid
-              description: Organization MCP servers used by this workflow
+              description: >-
+                MCP connectors attached to this workflow. May include a USER-scoped connector, which only
+                its owner can attach or keep attached when saving.
             outputs:
               type: array
               items:
@@ -31333,7 +31375,9 @@ components:
                 type: string
                 format: uuid
               default: []
-              description: Organization MCP servers used by this workflow
+              description: >-
+                MCP connectors attached to this workflow. May include a USER-scoped connector, which only
+                its owner can attach or keep attached when saving.
             outputs:
               type: array
               items:


### PR DESCRIPTION
Adds `McpServerScope` plus `scope` on `McpServerRequest`, and `scope`, `owner_user_sub`, `owner_name` and a per-caller `attachable` on `McpServerResponse`.

- `scope` carries no default: omitted means ORGANIZATION on create, unchanged on edit.
- `attachable` is computed per caller — an org admin sees every personal connector but may attach none, so `scope` alone cannot drive a picker.
- Documents the new 403 on `PUT /mcpServer/{id}` and per-owner name uniqueness on 409.

Backs QOV-2239, which makes an MCP connector either organization-wide or personal to one member.

Verified with `npx spectral lint openapi.yaml -r <spectral:oas>`: 268 problems / 4 errors, byte-identical to the pre-change baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents QOV-2239’s MCP connector scoping: connectors can be organization-wide or personal to one member, with ownership and per-caller attachability exposed by the API. The OpenAPI spec also clarifies permission checks and validation errors for creating, editing, and attaching connectors.

**API behavior**

- Omitting `scope` defaults to `ORGANIZATION` on create and preserves the existing scope on edit; changing it is rejected.
- Creating an organization connector requires `MANAGE_INFRASTRUCTURE`, while creating a personal connector requires `CREATE_PROJECT`; editing enforces the same rule, so an organization admin cannot edit a personal connector they don’t own.
- Personal connector names are unique per owner, and workflow saves reject connectors owned by another member or duplicate connector names.

<sup>Written for commit d9b442283019ced514710d908cbeed3329b11541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

