### PR TITLE
feat(agentic-workflow): document deploy endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14061,6 +14061,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
         '401':
           $ref: '#/components/responses/401'
         '403':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,6 +20,7 @@ tags:
   - name: Alert Rules
   - name: Admin
   - name: ArgoCD
+  - name: Agentic Workflows
   - name: Application
   - name: Application Actions
   - name: Application Configuration
@@ -174,6 +175,7 @@ x-tagGroups:
       - Jobs
       - Helms
       - Terraforms
+      - Agentic Workflows
       - Environment Actions
       - Environment Logs
       - Environment Deployment History
@@ -14041,6 +14043,30 @@ paths:
           $ref: '#/components/responses/404'
         '409':
           description: The deployment is already cancelled or cannot be cancelled in its current state
+  '/agenticWorkflow/{agenticWorkflowId}/deploy':
+    post:
+      summary: Deploy an agentic workflow
+      description: >-
+        Deploy the agentic workflow service so its configuration can be tested. Routine runs of the
+        workflow are triggered by its webhook or its schedule, not by this endpoint.
+      operationId: deployAgenticWorkflow
+      parameters:
+        - $ref: '#/components/parameters/agenticWorkflowId'
+      tags:
+        - Agentic Workflows
+      responses:
+        '202':
+          description: Deploy agentic workflow
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   '/agenticWorkflow/{agenticWorkflowId}/deploymentHistoryV2':
     get:
       summary: List agentic workflow deployments
@@ -21892,6 +21918,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TerraformDeployRequest'
+        agentic_workflows:
+          type: array
+          items:
+            type: string
+            format: uuid
     DeployRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14069,6 +14069,10 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          description: >-
+            The deployment request could not be queued because of a concurrent modification of the
+            environment deployment
   '/agenticWorkflow/{agenticWorkflowId}/deploymentHistoryV2':
     get:
       summary: List agentic workflow deployments


### PR DESCRIPTION
- Add `POST /agenticWorkflow/{agenticWorkflowId}/deploy` (`deployAgenticWorkflow`, no request body, 202 -> `Status`)
- Add optional `agentic_workflows` (array of uuid) to `DeployAllRequest`, mirroring `databases`
- Register the `Agentic Workflows` tag in root `tags` and in the Environment `x-tagGroups` entry
- Declare `400` on the deploy endpoint (`InvalidAction` / `ActionAlreadyInProgress` map to `BAD_REQUEST`), matching sibling deploys
- Declare `409` on the deploy endpoint: the queue append exhausted its optimistic-lock retries (`DeploymentConflict`), not the siblings' stale "operation is in progress"

Why: deploying an agentic workflow on demand lets its configuration be tested; routine runs come from its webhook or schedule.

Verified: `npm run html` exits 0 and bundles `_build/index.html`. `npm test` cannot run — its Stoplight ruleset URL in `.spectral.mjs` 404s, on `main` too; `spectral lint` with the built-in `spectral:oas` ruleset adds no new diagnostics and clears 7 `operation-tag-defined` warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deploy endpoint for agentic workflows so their configuration can be tested on demand, and lets `DeployAllRequest` include agentic workflows alongside databases. Registers the `Agentic Workflows` tag in the root tag list and the Environment tag group. No breaking changes; the new `agentic_workflows` field is optional.

The endpoint now also returns `400` when the workflow cannot be deployed (e.g., an ongoing action) and `409` when the deployment request hits an optimistic-lock conflict while being queued.

<sup>Written for commit de86897b89df3c4c7091ce89b51210f44f000719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-openapi-spec/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

